### PR TITLE
base-glibc-busybox-bash: Remove zlib and tini

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -93,11 +93,23 @@ jobs:
       run: |
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
-        existing_tags="$(
+        respone="$(
           curl -sL \
-            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image' \
-            | jq -r 'if .images == null then "" else .images[].tags[] end'
-        )"
+            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
+          )"
+
+        existing_tags="$(
+          printf %s "${respone}" \
+            | jq -r '.images[].tags[]'
+          )" \
+          || {
+            printf %s\\n \
+              'Could not get list of image tags.' \
+              'Does the repository exist on Quay.io?' \
+              'Quay.io REST API response was:' \
+              "${respone}"
+            exit 1
+          }
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           if [ \! "${tag}" = latest ] ; then
             printf %s "${existing_tags}" \

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -24,12 +24,6 @@ jobs:
       # similar to the larger base image (which does not use Debian 10+ because
       # of increased size due to additional dependencies pulled in for OpenGL).
       DEBIAN_VERSION: '9.13'
-      TEST_COMMAND: |
-        bash -c '\
-          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-          sh ./Miniconda3-latest-Linux-x86_64.sh -bp /opt/conda && \
-          /opt/conda/bin/conda info --all'
-
 
     steps:
     - uses: actions/checkout@v2
@@ -86,11 +80,14 @@ jobs:
 
     - name: Test Built Image
       run: |
+        image='${{ steps.buildah-build.outputs.image }}'
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
-          podman run --rm \
-            "${{ steps.buildah-build.outputs.image }}:${tag}" \
-            ${{ env.TEST_COMMAND }}
+          buildah bud \
+            --build-arg=base="${image}:${tag}" \
+            --file=Dockerfile.test \
+            "images/${image}"
         done
+        buildah rmi --prune || true
 
     - name: Check For Already Uploaded Tags
       run: |
@@ -127,6 +124,8 @@ jobs:
       run: |
         image='${{ secrets.QUAY_BIOCONDA_REPO }}/${{ steps.buildah-build.outputs.image }}'
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
-          podman run --rm "${image}:${tag}" \
-            ${{ env.TEST_COMMAND }}
+          buildah bud \
+            --build-arg=base="${image}:${tag}" \
+            --file=Dockerfile.test \
+            "images/${image}"
         done

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -44,7 +44,7 @@ RUN mkdir -p \
 RUN rm -rf ./lib ./lib64
 
 COPY install-pkgs /usr/local/bin
-RUN install-pkgs "$( pwd )" /tmp/work bash ncurses-base libc-bin zlib1g
+RUN install-pkgs "$( pwd )" /tmp/work bash ncurses-base libc-bin
 
 ARG tini_version=0.19.0
 ADD "https://github.com/krallin/tini/releases/download/v${tini_version}/tini-amd64" ./usr/bin/tini

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -46,18 +46,10 @@ RUN rm -rf ./lib ./lib64
 COPY install-pkgs /usr/local/bin
 RUN install-pkgs "$( pwd )" /tmp/work bash ncurses-base libc-bin
 
-ARG tini_version=0.19.0
-ADD "https://github.com/krallin/tini/releases/download/v${tini_version}/tini-amd64" ./usr/bin/tini
-RUN echo \
-      93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c\ ./usr/bin/tini \
-      | sha256sum --check \
-    && \
-    chmod +x ./usr/bin/tini
 COPY entrypoint ./opt/container/
-
 
 FROM scratch
 COPY --from=rootfs_builder /rootfs /
 ENV LANG=C.UTF-8
-ENTRYPOINT [ "/usr/bin/tini", "--", "/opt/container/entrypoint" ]
+ENTRYPOINT [ "/opt/container/entrypoint" ]
 CMD [ "bash" , "-l" ]

--- a/images/base-glibc-busybox-bash/Dockerfile.test
+++ b/images/base-glibc-busybox-bash/Dockerfile.test
@@ -1,0 +1,10 @@
+ARG base
+FROM "${base}"
+
+COPY --from=debian:9-slim /lib/x86_64-linux-gnu/libz.so* /lib/x86_64-linux-gnu/
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && \
+    sh ./Miniconda3-latest-Linux-x86_64.sh -bp /opt/conda \
+    && \
+    /opt/conda/bin/conda info --all

--- a/images/base-glibc-busybox-bash/entrypoint
+++ b/images/base-glibc-busybox-bash/entrypoint
@@ -1,5 +1,4 @@
-#! /bin/sh -l
-# Uses a login shell to run /etc/profile beforehand.
+#! /bin/sh
 
 # Chain exec entrypoints in /opt/container/ (entrypoint-001, entrypoint-002, ...), if any.
 # E.g., if the container is run with command `bash`, the `exec` line below may expand to


### PR DESCRIPTION
Address review from @bgruening from https://github.com/bioconda/bioconda-containers/pull/6 :
- Remove zlib from glibc-busybox-bash
- Remove init from glibc-busybox-bash

Also remove login shell from entrypoint for transparency 