### PR TITLE
Move terminfo library (libtinfo, libtic) out of standard library path

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '1.0.0'
+      IMAGE_VERSION: '1.0.1'
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.32.1'
       # Use Debian 9 instead of newer one for now to get an image which is more

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -43,6 +43,12 @@ RUN mkdir -p \
 # Remove glibc files. They are incomplete and get substituted by `install-pkgs`.
 RUN rm -rf ./lib ./lib64
 
+# Install helper tools used by install-pkgs.
+RUN apt-get update -qq \
+    && \
+    apt-get install --yes --no-install-recommends \
+      patchelf
+
 COPY install-pkgs /usr/local/bin
 RUN install-pkgs "$( pwd )" /tmp/work bash ncurses-base libc-bin
 

--- a/images/base-glibc-busybox-bash/install-pkgs
+++ b/images/base-glibc-busybox-bash/install-pkgs
@@ -10,6 +10,24 @@ prepare_remove_docs() {
 }
 
 
+add_rpath() {
+  local binary="${1}"
+  shift
+  local new_rpath="${1}"
+  shift
+  local rpath
+  rpath="$(
+    patchelf \
+      --print-rpath \
+      "${binary}"
+  )"
+  patchelf \
+    --set-rpath \
+    "${rpath:+${rpath}:}${new_rpath}" \
+    "${binary}"
+}
+
+
 prepare() {
   local pkg="${1}"
   shift
@@ -46,6 +64,29 @@ prepare() {
       ;;
     bash )
       rm -rf ./usr/share/locale
+      # Add custom rpath for libtinfo (see below) to bash binaries.
+      local new_rpath='/lib/x86_64-linux-gnu/terminfo:/usr/lib/x86_64-linux-gnu/terminfo'
+      add_rpath ./bin/bash "${new_rpath}"
+      add_rpath ./usr/bin/clear_console "${new_rpath}"
+      ;;
+    libtinfo5 | \
+    libtinfo6 )
+      # Move libtinfo libraries to a custom path to ensure it is not
+      # unintentionally used in downstream images.
+      find ./usr/lib/x86_64-linux-gnu -type f \
+        | {
+          while read binary ; do
+            add_rpath "${binary}" '/lib/x86_64-linux-gnu/terminfo'
+          done
+        }
+
+      mv ./lib/x86_64-linux-gnu ./temp
+      mkdir ./lib/x86_64-linux-gnu
+      mv ./temp ./lib/x86_64-linux-gnu/terminfo
+
+      mv ./usr/lib/x86_64-linux-gnu ./temp
+      mkdir ./usr/lib/x86_64-linux-gnu
+      mv ./temp ./usr/lib/x86_64-linux-gnu/terminfo
       ;;
     libc-bin | \
     libgcc1 | \
@@ -55,8 +96,6 @@ prepare() {
     gcc-10-base | \
     libcrypt1 | \
     libgcc-s1 | \
-    libtinfo5 | \
-    libtinfo6 | \
     ncurses-base | \
     zlib1g )
       :

--- a/images/base-glibc-busybox-bash/install-pkgs
+++ b/images/base-glibc-busybox-bash/install-pkgs
@@ -17,7 +17,7 @@ prepare() {
   shift
 
   case "${pkg}" in
-    libc6)
+    libc6 )
       # To reduce image size, remove all charset conversion modules apart
       # from smaller ones for some common encodings.
       # Update gconv-modules accordingly.
@@ -44,13 +44,24 @@ prepare() {
       iconvconfig --prefix ./
 
       ;;
-    bash)
+    bash )
       rm -rf ./usr/share/locale
       ;;
-    libc-bin|libgcc1|base-files|gcc-6-base|gcc-8-base|gcc-10-base|libcrypt1|libgcc-s1|libtinfo5|libtinfo6|ncurses-base|zlib1g)
+    libc-bin | \
+    libgcc1 | \
+    base-files | \
+    gcc-6-base | \
+    gcc-8-base | \
+    gcc-10-base | \
+    libcrypt1 | \
+    libgcc-s1 | \
+    libtinfo5 | \
+    libtinfo6 | \
+    ncurses-base | \
+    zlib1g )
       :
       ;;
-    *)
+    * )
       # Abort if we get an unexpected package.
       printf %s\\n "\`prepare\` not defined for ${pkg}" >&2
       return 1
@@ -72,18 +83,18 @@ postinst() {
   shift
 
   case "${pkg}" in
-    libc-bin)
+    libc-bin )
       cp -p --remove-destination \
         ./usr/share/libc-bin/nsswitch.conf \
         ./etc/nsswitch.conf
         postinst_ldconfig_trigger
       ;;
-    base-files)
+    base-files )
       cp "${destdir}/DEBIAN/postinst" ./base-files-postinst
       chroot ./ sh /base-files-postinst configure
       rm ./base-files-postinst
       ;;
-    bash)
+    bash )
       # Replace BusyBox's sh by Bash
       rm -f ./bin/sh
       ln -s /bin/bash ./bin/sh
@@ -102,13 +113,22 @@ postinst() {
 "\e[1;5D": backward-word
 EOF
       ;;
-    libc6|libgcc1|libcrypt1|libgcc-s1|libtinfo5|libtinfo6|zlib1g)
+    libc6 | \
+    libgcc1 | \
+    libcrypt1 | \
+    libgcc-s1 | \
+    libtinfo5 | \
+    libtinfo6 | \
+    zlib1g )
       postinst_ldconfig_trigger
       ;;
-    gcc-6-base|gcc-8-base|gcc-10-base|ncurses-base)
+    gcc-6-base | \
+    gcc-8-base | \
+    gcc-10-base | \
+    ncurses-base )
       :
       ;;
-    *)
+    * )
       # Abort if we get an unexpected package.
       printf %s\\n "\`postinst\` not defined for ${pkg}" >&2
       return 1


### PR DESCRIPTION
@bgruening, this is what I meant in https://github.com/bioconda/bioconda-containers/pull/6#discussion_r595944644 with
> > I see, I'm just worried that the shared lib (ncurses) infers with conda stuff, or that we do not test for ncurses anymore etc ...
> 
> I'd assume it wouldn't be too bad since it's just terminfo and not the whole ncurses.(?)
> If you do have concerns, we could also simply move the `libtinfo*.so*` files to another path and add an RPATH to `bash` so it will find it, but nothing else would. WDYT?

(Actual changes are in https://github.com/bioconda/bioconda-containers/commit/9fdc42aad111921868ba9ed26301860d47fa531f .)

This way the `*.so*` files aren't directly available at `/lib/x86_64-linux-gnu`/`/usr/lib/x86_64-linux-gnu` but are moved to `/lib/x86_64-linux-gnu/terminfo`/`/usr/lib/x86_64-linux-gnu/terminfo` so they should not be picked up by anything apart from the Bash binaries we taught were to look.

Let me know if you'd like to include this change in the image.