### PR TITLE
Add base-glibc-debian-bash

### DIFF
--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -75,9 +75,15 @@ jobs:
     - name: Test Built Image
       run: |
         image='${{ steps.buildah-build.outputs.image }}'
-        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+        ids="$(
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            buildah images --quiet --no-trunc "${image}:${tag}"
+          done
+          )"
+        ids="$( printf %s "${ids}" | sort -u )"
+        for id in ${ids} ; do
           buildah bud \
-            --build-arg=base="${image}:${tag}" \
+            --build-arg=base="${id}" \
             --file=Dockerfile.test \
             "images/${image}"
         done
@@ -128,10 +134,16 @@ jobs:
     - if: ${{ github.ref == 'refs/heads/main' }}
       name: Test Uploaded Image
       run: |
-        image='${{ secrets.QUAY_BIOCONDA_REPO }}/${{ steps.buildah-build.outputs.image }}'
-        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+        image='${{ steps.buildah-build.outputs.image }}'
+        ids="$(
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            buildah images --quiet --no-trunc "${image}:${tag}"
+          done
+        )"
+        ids="$( printf %s "${ids}" | sort -u )"
+        for id in ${ids} ; do
           buildah bud \
-            --build-arg=base="${image}:${tag}" \
+            --build-arg=base="${id}" \
             --file=Dockerfile.test \
             "images/${image}"
         done

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -1,0 +1,137 @@
+name: Build and Push Image "base-glibc-debian-bash"
+on:
+  push:
+    branch: main
+    paths:
+    - images/base-glibc-debian-bash/*
+    - .github/workflows/base-glibc-debian-bash.yaml
+  pull_request:
+    paths:
+    - images/base-glibc-debian-bash/*
+    - .github/workflows/base-glibc-debian-bash.yaml
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-20.04
+    env:
+      # The base image is not intended to change often and should be used with
+      # version tags or checksum IDs, but not via "latest".
+      IMAGE_VERSION: '1.0.0'
+      IMAGE_NAME: base-glibc-debian-bash
+      # Use Debian 9 instead of newer one for now to get an image which is more
+      # similar to the larger base image (which does not use Debian 10+ because
+      # of increased size due to additional dependencies pulled in for OpenGL).
+      DEBIAN_VERSION: '9.13'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build Image
+      id: buildah-build
+      run: |
+        set -xeu
+        cd 'images/${{ env.IMAGE_NAME }}'
+
+        iidfile="$( mktemp )"
+        buildah bud --layers \
+          --iidfile="${iidfile}" \
+          --build-arg=debian_version="${{ env.DEBIAN_VERSION }}"
+        image_id="$( cat "${iidfile}" )"
+        rm "${iidfile}"
+
+        container="$( buildah from "${image_id}" )"
+        run() { buildah run "${container}" "${@}" ; }
+        glibc="$( run sh -c 'exec "$( find /lib -name libc.so.6 -print -quit )"' | sed '1!d' )"
+        debian="$( run cat /etc/debian_version | sed '1!d' )"
+        bash="$( run bash --version | sed '1!d' )"
+        buildah rm "${container}"
+
+        container="$( buildah from "${image_id}" )"
+        buildah config --label=glibc="${glibc}" "${container}"
+        buildah config --label=debian="${debian}" "${container}"
+
+        glibc_version="$( printf %s "${glibc}" | sed -E 's/.*version ([0-9.]*[0-9]).*/\1/' )"
+        debian_version="$( printf %s "${debian}" | sed -E '1 s/.*v([0-9.]*[0-9]).*/\1/' )"
+        bash_version="$( printf %s "${bash}" | sed -E 's/.*version ([0-9.]*[0-9]).*/\1/' )"
+        tags="
+          ${{ env.IMAGE_VERSION }}
+          ${{ env.IMAGE_VERSION }}_${glibc_version}_${debian_version}_${bash_version}
+          latest
+        "
+
+        image_id="$( buildah commit "${container}" )"
+        buildah rm "${container}"
+        image_name='${{ env.IMAGE_NAME }}'
+
+        for tag in ${tags} ; do
+          buildah tag "${image_id}" \
+            "${image_name}":"${tag}"
+        done
+
+        echo "::set-output name=image::${image_name}"
+        echo "::set-output name=tags::$( echo ${tags} )"
+
+    - name: Test Built Image
+      run: |
+        image='${{ steps.buildah-build.outputs.image }}'
+        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          buildah bud \
+            --build-arg=base="${image}:${tag}" \
+            --file=Dockerfile.test \
+            "images/${image}"
+        done
+        buildah rmi --prune || true
+
+    - name: Check For Already Uploaded Tags
+      run: |
+        # FIX upstream: Quay.io does not support immutable images currently.
+        #               => Try to use the REST API to check for duplicate tags.
+        respone="$(
+          curl -sL \
+            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
+          )"
+
+        existing_tags="$(
+          printf %s "${respone}" \
+            | jq -r '.images[].tags[]'
+          )" \
+          || {
+            printf %s\\n \
+              'Could not get list of image tags.' \
+              'Does the repository exist on Quay.io?' \
+              'Quay.io REST API response was:' \
+              "${respone}"
+            exit 1
+          }
+        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          if [ \! "${tag}" = latest ] ; then
+            printf %s "${existing_tags}" \
+              | grep -qxF "${tag}" \
+            && {
+              printf 'Tag %s already exists!\n' "${tag}"
+              exit 1
+            }
+          fi
+        done
+
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Push To Quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.buildah-build.outputs.image }}
+        tags: ${{ steps.buildah-build.outputs.tags }}
+        registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
+        username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
+        password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
+
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Test Uploaded Image
+      run: |
+        image='${{ secrets.QUAY_BIOCONDA_REPO }}/${{ steps.buildah-build.outputs.image }}'
+        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          buildah bud \
+            --build-arg=base="${image}:${tag}" \
+            --file=Dockerfile.test \
+            "images/${image}"
+        done

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -1,0 +1,33 @@
+ARG debian_version=9.13
+
+FROM "debian:${debian_version}-slim"
+
+RUN apt-get update -qq \
+    && \
+    apt-get install --yes \
+      --no-install-recommends \
+      libgl1-mesa-glx \
+      locales \
+      openssh-client \
+      procps \
+    && \
+    # Add en_US.UTF-8 locale.
+    sed -i \
+      's/^# *\(en_US.UTF-8\)/\1/' \
+      /etc/locale.gen \
+    && \
+    locale-gen \
+    && \
+    # Remove "locales" package, but keep the generated locale.
+    sed -i \
+      's/\s*rm .*locale-archive$/: &/' \
+      /var/lib/dpkg/info/locales.prerm \
+    && \
+    apt-get remove --yes \
+      locales \
+    && \
+    # Remove apt package lists.
+    rm -rf /var/lib/apt/lists/*
+
+ENV LANG=C.UTF-8
+CMD [ "bash" , "-l" ]

--- a/images/base-glibc-debian-bash/Dockerfile.test
+++ b/images/base-glibc-debian-bash/Dockerfile.test
@@ -1,0 +1,19 @@
+ARG base
+FROM "${base}"
+
+# Check if all desired locales are there.
+RUN locale -a | grep -i 'c\.utf-\?8' \
+    && \
+    locale -a | grep -i 'en_us\.utf-\?8'
+
+RUN apt-get update -qq \
+    && \
+    apt-get install --yes --no-install-recommends \
+      ca-certificates \
+      wget \
+    && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && \
+    sh ./Miniconda3-latest-Linux-x86_64.sh -bp /opt/conda \
+    && \
+    /opt/conda/bin/conda info --all


### PR DESCRIPTION
This is essentially the same as https://github.com/bioconda/bioconda-extended-base-image but with minor updates:
- This image is now versioned.
- Updates to Debian 9.
- Uses `debian:*-slim` instead of `bitnami/minideb`.
  From `debian:9-slim` onward, the sizes of both images are near-identical, so it makes more sense to use the more common one.
- Just like `bioconda/extended-base-image`, this adds `libgl1-mesa-glx`, `openssh-client`, `procps` for compatibility.
  It does not retain the `locales` package, though. But it still includes the generated `en_US.UTF-8` locale for backwards compatibility. The standard locale is now set to `C.UTF-8` to be in line with `bioconda/base-glibc-busybox-bash` (the build container will also include this `C.UTF-8` locale to avoid incompatibilities due to non-existing locales we encountered before).