### PR TITLE
Add activation and entrypoint scripts under /usr/local

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '1.0.1'
+      IMAGE_VERSION: '1.1.0'
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.32.1'
       # Use Debian 9 instead of newer one for now to get an image which is more

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -82,6 +82,7 @@ jobs:
           )"
         ids="$( printf %s "${ids}" | sort -u )"
         for id in ${ids} ; do
+          podman history "${id}"
           buildah bud \
             --build-arg=base="${id}" \
             --file=Dockerfile.test \
@@ -142,6 +143,7 @@ jobs:
         )"
         ids="$( printf %s "${ids}" | sort -u )"
         for id in ${ids} ; do
+          podman history "${id}"
           buildah bud \
             --build-arg=base="${id}" \
             --file=Dockerfile.test \

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -17,7 +17,7 @@ jobs:
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '1.0.0'
+      IMAGE_VERSION: '1.1.0'
       IMAGE_NAME: base-glibc-debian-bash
       # Use Debian 9 instead of newer one for now to get an image which is more
       # similar to the larger base image (which does not use Debian 10+ because

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -52,7 +52,7 @@ jobs:
         buildah config --label=debian="${debian}" "${container}"
 
         glibc_version="$( printf %s "${glibc}" | sed -E 's/.*version ([0-9.]*[0-9]).*/\1/' )"
-        debian_version="$( printf %s "${debian}" | sed -E '1 s/.*v([0-9.]*[0-9]).*/\1/' )"
+        debian_version="$( printf %s "${debian}" | sed -E 's|/|_|g' )"
         bash_version="$( printf %s "${bash}" | sed -E 's/.*version ([0-9.]*[0-9]).*/\1/' )"
         tags="
           ${{ env.IMAGE_VERSION }}

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -31,8 +31,8 @@ COPY --from=target_base / ./
 RUN find . -samefile ./bin/busybox -delete
 COPY --from=busybox_builder /busybox/busybox ./
 RUN mkdir -p \
-      ./bin ./usr/bin ./usr/local/bin \
-      ./sbin ./usr/sbin ./usr/local/sbin \
+      ./bin ./usr/bin \
+      ./sbin ./usr/sbin \
     && \
     chroot . /busybox --install \
     && \
@@ -50,7 +50,15 @@ RUN apt-get update -qq \
       patchelf
 
 COPY install-pkgs /usr/local/bin
-RUN install-pkgs "$( pwd )" /tmp/work bash ncurses-base libc-bin
+RUN install-pkgs "$( pwd )" /tmp/work \
+      bash \
+      ncurses-base \
+      libc-bin \
+    && \
+    # Remove contents of /usr/local as downstream images overwrite those.
+    find ./usr/local/ \
+      -mindepth 1 -depth \
+      -delete
 
 FROM scratch
 COPY --from=rootfs_builder /rootfs /

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -60,7 +60,29 @@ RUN install-pkgs "$( pwd )" /tmp/work \
       -mindepth 1 -depth \
       -delete
 
+# env-activate.sh (+ optionally env-execute) should be overwritten downstream.
+# - env-activate.sh:
+#    Is sourced (via symlink in /etc/profile.d/) to activate the /usr/local env.
+# - env-execute:
+#    Is set as the ENTRYPOINT to activate /usr/local before exec'ing CMD.
+RUN touch ./usr/local/env-activate.sh \
+    && \
+    touch ./usr/local/env-execute \
+    && \
+    chmod +x ./usr/local/env-execute \
+    && \
+    ln -s \
+      /usr/local/env-activate.sh \
+      ./etc/profile.d/env-activate.sh \
+    && \
+    printf '%s\n' \
+      '#! /bin/sh' \
+      ". '/usr/local/env-activate.sh'" \
+      'exec "${@}"' \
+      > ./usr/local/env-execute
+
 FROM scratch
 COPY --from=rootfs_builder /rootfs /
 ENV LANG=C.UTF-8
-CMD [ "bash" , "-l" ]
+ENTRYPOINT [ "/usr/local/env-execute" ]
+CMD [ "bash" ]

--- a/images/base-glibc-busybox-bash/Dockerfile.test
+++ b/images/base-glibc-busybox-bash/Dockerfile.test
@@ -1,8 +1,23 @@
 ARG base
 FROM "${base}"
 
-COPY --from=debian:9-slim /lib/x86_64-linux-gnu/libz.so* /lib/x86_64-linux-gnu/
+# Check if env-activate.sh gets sourced for login shell and in env-execute.
+RUN [ "$( sh -lc 'printf world' )" = 'world' ] \
+    && \
+    [ "$( /usr/local/env-execute sh -c 'printf world' )" = 'world' ] \
+    && \
+    printf '%s\n' \
+      'printf "hello "' \
+      > /usr/local/env-activate.sh \
+    && \
+    [ "$( sh -lc 'printf world' )" = 'hello world' ] \
+    && \
+    [ "$( /usr/local/env-execute sh -c 'printf world' )" = 'hello world' ] \
+    && \
+    printf '' \
+      > /usr/local/env-activate.sh
 
+COPY --from=debian:9-slim /lib/x86_64-linux-gnu/libz.so* /lib/x86_64-linux-gnu/
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && \
     sh ./Miniconda3-latest-Linux-x86_64.sh -bp /opt/conda \

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -34,5 +34,27 @@ RUN apt-get update -qq \
       -mindepth 1 -depth \
       -delete
 
+# env-activate.sh (+ optionally env-execute) should be overwritten downstream.
+# - env-activate.sh:
+#    Is sourced (via symlink in /etc/profile.d/) to activate the /usr/local env.
+# - env-execute:
+#    Is set as the ENTRYPOINT to activate /usr/local before exec'ing CMD.
+RUN touch /usr/local/env-activate.sh \
+    && \
+    touch /usr/local/env-execute \
+    && \
+    chmod +x /usr/local/env-execute \
+    && \
+    ln -s \
+      /usr/local/env-activate.sh \
+      /etc/profile.d/env-activate.sh \
+    && \
+    printf '%s\n' \
+      '#! /bin/sh' \
+      ". '/usr/local/env-activate.sh'" \
+      'exec "${@}"' \
+      > /usr/local/env-execute
+
 ENV LANG=C.UTF-8
-CMD [ "bash" , "-l" ]
+ENTRYPOINT [ "/usr/local/env-execute" ]
+CMD [ "bash" ]

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -27,7 +27,12 @@ RUN apt-get update -qq \
       locales \
     && \
     # Remove apt package lists.
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
+    && \
+    # Remove contents of /usr/local as downstream images overwrite those.
+    find ./usr/local/ \
+      -mindepth 1 -depth \
+      -delete
 
 ENV LANG=C.UTF-8
 CMD [ "bash" , "-l" ]

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -34,6 +34,19 @@ RUN apt-get update -qq \
       -mindepth 1 -depth \
       -delete
 
+# Bash 4.* did not have default key bindings for control-arrow-key key
+# combinations. Add some for convenience:
+RUN >> /etc/inputrc \
+      printf '%s\n' \
+      '' \
+      '"\e[5C": forward-word' \
+      '"\e[5D": backward-word' \
+      '"\e\e[C": forward-word' \
+      '"\e\e[D": backward-word' \
+      '"\e[1;5C": forward-word' \
+      '"\e[1;5D": backward-word' \
+      ;
+
 # env-activate.sh (+ optionally env-execute) should be overwritten downstream.
 # - env-activate.sh:
 #    Is sourced (via symlink in /etc/profile.d/) to activate the /usr/local env.

--- a/images/base-glibc-debian-bash/Dockerfile.test
+++ b/images/base-glibc-debian-bash/Dockerfile.test
@@ -1,6 +1,22 @@
 ARG base
 FROM "${base}"
 
+# Check if env-activate.sh gets sourced for login shell and in env-execute.
+RUN [ "$( sh -lc 'printf world' )" = 'world' ] \
+    && \
+    [ "$( /usr/local/env-execute sh -c 'printf world' )" = 'world' ] \
+    && \
+    printf '%s\n' \
+      'printf "hello "' \
+      > /usr/local/env-activate.sh \
+    && \
+    [ "$( sh -lc 'printf world' )" = 'hello world' ] \
+    && \
+    [ "$( /usr/local/env-execute sh -c 'printf world' )" = 'hello world' ] \
+    && \
+    printf '' \
+      > /usr/local/env-activate.sh
+
 # Check if all desired locales are there.
 RUN locale -a | grep -i 'c\.utf-\?8' \
     && \


### PR DESCRIPTION
- Add `/usr/local/env-activate.sh`:
  Contents of this file get sourced for login shells (via `/etc/profile` -> `/etc/profile.d/env-activate.sh` -> `/usr/local/env-activate.sh`).
  In the base images this file is empty, i.e., no changes happen.
  In downstream images this file can be populated with instructions from `conda shell.posix activate /usr/local` to automatically activate (Conda) environments in the image.
- Add `/usr/loca/env-execute` as entrypoint:
  This sources the contents of `/usr/loca/env-activate.sh` before executing the command passed on (default: `CMD [ "bash" ]`).
  Via this entrypoint we ensure activated (Conda) environments not only for login shells but all commands for which the container image is entered.
- Remove contents of `/usr/local` (replaced downstream anyway), apart from the added `env-activate.sh`/`env-execute`.
- Bump base image versions to `1.1.0`.