### PR TITLE
Add container image bioconda/create-env

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -118,12 +118,10 @@ jobs:
           }
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           if [ \! "${tag}" = latest ] ; then
-            printf %s "${existing_tags}" \
-              | grep -qxF "${tag}" \
-            && {
+            if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
               printf 'Tag %s already exists!\n' "${tag}"
               exit 1
-            }
+            fi
           fi
         done
 
@@ -153,3 +151,4 @@ jobs:
             --file=Dockerfile.test \
             "images/${image}"
         done
+        buildah rmi --prune || true

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -113,12 +113,10 @@ jobs:
           }
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           if [ \! "${tag}" = latest ] ; then
-            printf %s "${existing_tags}" \
-              | grep -qxF "${tag}" \
-            && {
+            if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
               printf 'Tag %s already exists!\n' "${tag}"
               exit 1
-            }
+            fi
           fi
         done
 
@@ -149,3 +147,4 @@ jobs:
             --file=Dockerfile.test \
             "images/${image}"
         done
+        buildah rmi --prune || true

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -1,0 +1,114 @@
+name: Build and Push Image "create-env"
+on:
+  push:
+    branch: main
+    paths:
+    - images/create-env/*
+    - .github/workflows/create-env.yaml
+  pull_request:
+    paths:
+    - images/create-env/*
+    - .github/workflows/create-env.yaml
+
+jobs:
+  build:
+    name: Build and Push Image
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_VERSION: '1.0.0'
+      VERSION: '4.9.2'
+      IMAGE_NAME: create-env
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build Image
+      id: buildah-build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: >-
+          latest
+          ${{ env.IMAGE_VERSION }}-${{ env.VERSION }}
+        context: ./images/${{ env.IMAGE_NAME }}
+        dockerfiles: |
+          ./images/${{ env.IMAGE_NAME }}/Dockerfile
+        build-args: |
+          version=${{ env.VERSION }}
+
+    - name: Test Built Image
+      run: |
+        image='${{ steps.buildah-build.outputs.image }}'
+        ids="$(
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            buildah images --quiet --no-trunc "${image}:${tag}"
+          done
+          )"
+        ids="$( printf %s "${ids}" | sort -u )"
+        for id in ${ids} ; do
+          buildah bud \
+            --build-arg=base="${id}" \
+            --file=Dockerfile.test \
+            "images/${image}"
+        done
+        buildah rmi --prune || true
+
+    - name: Check For Already Uploaded Tags
+      run: |
+        # FIX upstream: Quay.io does not support immutable images currently.
+        #               => Try to use the REST API to check for duplicate tags.
+        respone="$(
+          curl -sL \
+            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
+          )"
+
+        existing_tags="$(
+          printf %s "${respone}" \
+            | jq -r '.images[].tags[]'
+          )" \
+          || {
+            printf %s\\n \
+              'Could not get list of image tags.' \
+              'Does the repository exist on Quay.io?' \
+              'Quay.io REST API response was:' \
+              "${respone}"
+            exit 1
+          }
+        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          if [ \! "${tag}" = latest ] ; then
+            printf %s "${existing_tags}" \
+              | grep -qxF "${tag}" \
+            && {
+              printf 'Tag %s already exists!\n' "${tag}"
+              exit 1
+            }
+          fi
+        done
+
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Push To Quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.buildah-build.outputs.image }}
+        tags: ${{ steps.buildah-build.outputs.tags }}
+        registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
+        username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
+        password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
+
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Test Uploaded Image
+      run: |
+        image='${{ steps.buildah-build.outputs.image }}'
+        ids="$(
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            buildah images --quiet --no-trunc "${image}:${tag}"
+          done
+          )"
+        ids="$( printf %s "${ids}" | sort -u )"
+        for id in ${ids} ; do
+          buildah bud \
+            --build-arg=base="${id}" \
+            --file=Dockerfile.test \
+            "images/${image}"
+        done
+        buildah rmi --prune || true

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -76,12 +76,10 @@ jobs:
           }
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           if [ \! "${tag}" = latest ] ; then
-            printf %s "${existing_tags}" \
-              | grep -qxF "${tag}" \
-            && {
+            if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
               printf 'Tag %s already exists!\n' "${tag}"
               exit 1
-            }
+            fi
           fi
         done
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -1,0 +1,34 @@
+# Use Debian instead of BusyBox base since Miniconda currently needs external zlib.
+FROM bioconda/base-glibc-debian-bash as build
+
+WORKDIR /tmp/work
+COPY install-conda print-env-activate create-env ./
+ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh ./miniconda.sh
+
+ARG version='4.9.2'
+RUN ./install-conda "${version}" /opt/create-env
+
+
+FROM bioconda/base-glibc-busybox-bash
+
+COPY --from=build /opt/create-env /opt/create-env
+# Copy (Bioconda-specific) Conda configuration created by the install-conda script.
+COPY --from=build /root/.condarc /root/
+
+RUN cp /opt/create-env/env-activate.sh /usr/local/ \
+    && \
+    # Use a per-user config (instead of conda config --sys) for more flexibility.
+    cp /root/.condarc /etc/skel/ \
+    && \
+    # Enable conda shell function for login shells.
+    ln -s /opt/create-env/etc/profile.d/conda.sh /etc/profile.d/ \
+    && \
+    # Enable conda function in interactive Bash (via .bashrc) and POSIX shells (via ENV).
+    printf '%s\n' \
+      '\. /etc/profile.d/conda.sh' \
+      | tee -a /root/.bashrc \
+      >>   /etc/skel/.bashrc
+ENV ENV=/etc/profile.d/conda.sh
+
+ENTRYPOINT [ "/opt/create-env/bin/tini", "--", "/usr/local/env-execute" ]
+CMD [ "bash" ]

--- a/images/create-env/Dockerfile.test
+++ b/images/create-env/Dockerfile.test
@@ -1,0 +1,48 @@
+ARG base
+
+
+FROM "${base}" as build_bioconda_utils
+RUN /opt/create-env/env-execute \
+      create-env \
+        --conda=mamba \
+        --strip \
+        /usr/local \
+        bioconda-utils
+FROM bioconda/base-glibc-busybox-bash
+COPY --from=build_bioconda_utils /usr/local /usr/local
+RUN /usr/local/env-execute \
+      bioconda-utils --version \
+    && \
+    [ ! "${CONDA_PREFIX}" = /usr/local ] \
+    && \
+    { set -x && . /usr/local/env-activate.sh && set +x ; } \
+    && \
+    [ "${CONDA_PREFIX}" = /usr/local ] \
+    && \
+    bioconda-utils --version
+
+
+FROM "${base}" as build_conda
+RUN /usr/local/env-execute \
+      create-env \
+        --conda=mamba \
+        --env-activate-args='--prefix-is-base' \
+        --strip \
+        --remove-files=\*.a \
+        --remove-files=\*.pyc \
+        /opt/conda \
+        conda
+FROM bioconda/base-glibc-busybox-bash
+COPY --from=build_conda /opt/conda /opt/conda
+COPY --from=build_conda /opt/conda/env-activate.sh /usr/local/
+RUN /usr/local/env-execute \
+      conda info --all \
+    && \
+    { set -x && . /usr/local/env-activate.sh && set +x ; } \
+    && \
+    . "${CONDA_PREFIX}/etc/profile.d/conda.sh" \
+    && \
+    conda activate \
+    && \
+    conda info \
+      | grep 'base environment.*/opt/conda'

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -1,0 +1,118 @@
+#! /bin/sh -eu
+
+for arg do
+  case "${arg}" in
+    --help )
+      cat <<'end-of-help'
+Usage: create-env [OPTIONS]... [--] PREFIX [CONDA_CREATE_ARGS]...
+Use conda (or mamba via --conda=mamba) to create a Conda environment at PREFIX
+according to specifications given by CONDA_CREATE_ARGS.
+
+  --conda=CONDA               text
+  --env-activate-args=ARGS    text
+  --env-activate-script=FILE  text
+  --env-execute-script=FILE   text
+  --remove-files=GLOB         text
+  --strip[=yes|=no]           text
+end-of-help
+      exit 0 ;;
+    --conda=* )
+      conda_impl="${arg#--conda=}"
+      shift ;;
+    --env-activate-args=* )
+      env_activate_args="${arg#--env-activate-args=}"
+      shift ;;
+    --env-activate-script=* )
+      env_activate_file="${arg#--env-activate-script=}"
+      shift ;;
+    --env-execute-script=* )
+      env_execute_file="${arg#--env-execute-script=}"
+      shift ;;
+    --remove-files=* )
+      remove_files_globs="$(
+        printf '%s\n' \
+          ${remove_files_globs+"${remove_files_globs}"} \
+          "${arg#--remove-files=}"
+      )"
+      shift ;;
+    --strip=yes | --strip )
+      strip=1 ; shift ;;
+    --strip=no )
+      strip=0 ; shift ;;
+    -- )
+      break ;;
+    -* )
+      printf 'unknown option: %s\n' "${arg}"
+      exit 1 ;;
+    * )
+      break
+  esac
+done
+
+if [ $# -eq 0 ] ; then
+  printf 'missing argument: environment path\n'
+  exit 1
+fi
+
+prefix="${1%%/}"
+shift
+
+conda_impl="${conda_impl:-conda}"
+env_activate_args="--prefix='${prefix}' ${env_activate_args-}"
+env_activate_file="${env_activate_file-"${prefix}/env-activate.sh"}"
+env_execute_file="${env_execute_file-"${prefix}/env-execute"}"
+remove_files_globs="$( printf '%s\n' "${remove_files_globs-}" | sort -u )"
+strip="${strip-0}"
+
+
+set +u
+eval "$( conda shell.posix activate base )"
+set -u
+
+# Use --copy to cut links to package cache.
+# (Which is esp. important if --strip or --remove-files are used!)
+${conda_impl} create --yes --copy --prefix="${prefix}" "${@}"
+
+if [ -n "${env_activate_file-}${env_execute_file-}" ] ; then
+  activate_script="$(
+    eval "set -- ${env_activate_args}"
+    print-env-activate "${@}"
+  )"
+  if [ -n "${env_activate_file-}" ] ; then
+    printf '%s\n' \
+      "${activate_script}" \
+      > "${env_activate_file}"
+    activate_script=". '${env_activate_file}'"
+  fi
+  if [ -n "${env_execute_file-}" ] ; then
+    printf '%s\n' \
+      '#! /bin/sh' \
+      "${activate_script}" \
+      'exec "${@}"' \
+      > "${env_execute_file}"
+    chmod +x "${env_execute_file}"
+  fi
+fi
+
+if [ -n "${remove_files_globs}" ] ; then
+  (
+    eval "set -- $(
+      printf %s "${remove_files_globs}" \
+        | sed -e "s|.*|-path '${prefix}/&'|" -e '1!s/^/-o /' \
+        | tr '\n' ' '
+    )"
+    find "${prefix}" \
+      -type f \
+      \( "${@}" \) \
+      -delete
+  )
+fi
+
+if [ "${strip}" = 1 ] ; then
+  # Strip binaries. (Run strip on all files; ignore errors for non-ELF files.)
+  find "${prefix}" \
+    -type f \
+    -exec strip {} \+ \
+    2> /dev/null \
+    || true
+fi

--- a/images/create-env/install-conda
+++ b/images/create-env/install-conda
@@ -1,0 +1,99 @@
+#! /bin/sh -eu
+
+version="${1}"
+conda_install_prefix="${2}"
+
+# Run the following in a subshell to avoid environment changes from bootstrap.
+(
+  # Install a bootstrap Miniconda installation.
+  miniconda_boostrap_prefix="$( pwd )/miniconda"
+  sh ./miniconda.sh \
+    -b \
+    -p "${miniconda_boostrap_prefix}"
+
+  # Install the base Conda installation.
+  . "${miniconda_boostrap_prefix}/etc/profile.d/conda.sh"
+
+  # Install conda and some additional tools:
+  #  - tini: init program,
+  #  - binutils, findutils: tools to strip down image/environment size,
+  #  - mamba: alternative Conda package manager.
+
+  # Only need `strip` executable from binutils. Other binaries from the package
+  # and especially the "sysroot" dependency is only bloat for this container
+  # image. (NOTE: The binary needs libgcc-ng which is explicitly added later.)
+  conda create --yes \
+    --prefix="${conda_install_prefix}" \
+    --channel=conda-forge \
+    binutils
+  tmp_dir="${miniconda_boostrap_prefix}/tmp-strip"
+  mkdir "${tmp_dir}"
+  mv "${conda_install_prefix}/bin/"*strip "${tmp_dir}/"
+  conda remove --yes --all \
+    --prefix="${conda_install_prefix}"
+
+  conda create --yes \
+    --prefix="${conda_install_prefix}" \
+    --channel=conda-forge \
+    \
+    conda="${version}" \
+    \
+    tini \
+    \
+    libgcc-ng \
+    findutils \
+    \
+    mamba \
+    ;
+
+  mv \
+    ./print-env-activate \
+    ./create-env \
+    "${tmp_dir}/"* \
+    "${conda_install_prefix}/bin/"
+  rmdir "${tmp_dir}"
+
+  # Remove bootstrap Miniconda files.
+  rm -rf "${miniconda_boostrap_prefix}"
+)
+
+# Activate the new base environment.
+activate_script="$(
+  "${conda_install_prefix}/bin/conda" shell.posix activate base
+)"
+set +u
+eval "${activate_script}"
+set -u
+unset activate_script
+
+
+# Use --conda=: to turn the `conda create` into a no-op, but do continue to
+# run strip, remove files and output the activate/execute scripts.
+create-env \
+  --conda=: \
+  --strip \
+  --remove-files=\*.a \
+  --remove-files=\*.pyc \
+  --env-activate-args=--prefix-is-base \
+  "${conda_install_prefix}"
+
+# Add standard Bioconda config to root's Conda config.
+conda config \
+  --append channels conda-forge \
+  --append channels bioconda \
+  --append channels defaults \
+  ;
+conda config \
+  --remove repodata_fns current_repodata.json \
+  2> /dev/null \
+  || true
+conda config \
+  --prepend repodata_fns repodata.json
+
+
+# Log information of the newly created Conda installation.
+# NB: Running conda after the .pyc removal will recreate some .pyc files.
+#     This is intentional as it speeds up conda startup time.
+conda list --name=base
+conda info --all
+mamba --version

--- a/images/create-env/print-env-activate
+++ b/images/create-env/print-env-activate
@@ -1,0 +1,92 @@
+#! /bin/sh -eu
+
+for arg do
+  case "${arg}" in
+    --help )
+      cat <<'end-of-help'
+Usage: print-env-activate [OPTIONS]... [PREFIX]
+Print shell activation script contents conda creates for environment at PREFIX.
+
+  --prefix=ENVIRONMENT        text
+  --prefix-is-base[=yes|=no]  text
+end-of-help
+      exit 0 ;;
+    --prefix=* )
+      prefix="${arg#--prefix=}"
+      shift ;;
+    --prefix-is-base=yes | --prefix-is-base )
+      prefix_is_base=1
+      shift ;;
+    --prefix-is-base=no )
+      prefix_is_base=0
+      shift ;;
+    -- )
+      break ;;
+    -* )
+      printf 'unknown option: %s\n' "${arg}"
+      exit 1 ;;
+    * )
+      break
+  esac
+done
+
+if [ -z "${prefix:-}" ] ; then
+  prefix="${1}"
+  shift
+fi
+
+if [ $# -ne 0 ] ; then
+  printf 'excess argument: %s\n' "${@}"
+  exit
+fi
+
+if [ "${prefix_is_base-}" = 1 ] ; then
+  conda_exe="${prefix}/bin/conda"
+else
+  conda_exe="$( command -v conda )"
+fi
+
+# Deactivate current active env for full `conda shell.posix activate` changes.
+deactivate_script="$(
+  conda shell.posix deactivate
+)"
+if [ "${prefix_is_base-}" = 1 ] ; then
+  deactivate_script="$(
+    printf %s "${deactivate_script}" \
+      | sed "s|/[^\"'=:]*/condabin:||g"
+  )"
+fi
+set +u
+eval "${deactivate_script}"
+set -u
+unset deactivate_script
+
+# NOTE: The following gets a proper PS1 value from an interactive Bash which
+#       `conda shell posix.activate` can reuse.
+# NB: Ideally, conda activate should not use the current PS1 but rather write
+#     out something like PS1="${CONDA_PROMPT_MODIFIER}${PS1}".
+#     (Also, running this in the build instead of final container might not
+#     reflect the actual PS1 the target container image would provide.)
+PS1="$(
+  bash -ic 'printf %s "${PS1}"'
+  printf .
+)"
+PS1="${PS1%.}"
+
+activate_script="$(
+  export PS1
+  if [ ! "${prefix_is_base-}" = 1 ] ; then
+    export CONDA_ENV_PROMPT=
+  fi
+  "${conda_exe}" shell.posix activate "${prefix}"
+)"
+
+printf '%s\n' "${activate_script}" \
+  | {
+    if [ "${prefix_is_base-}" = 1 ] ; then
+        cat
+    else
+      grep -vE '^export (_CE_M|_CE_CONDA|CONDA_EXE|CONDA_PYTHON_EXE)=' \
+        | sed "s|/[^\"'=:]*/condabin:||g"
+    fi
+    }


### PR DESCRIPTION
This, in conjunction with the activation/entrypoint scripts from gh-12, lets one create container images from Bioconda packages easily like so:
```Dockerfile
ARG base=bioconda/base-glibc-busybox-bash

FROM bioconda/create-env as build
RUN /usr/local/env-execute \
      create-env \
        --conda=mamba \
        /usr/local \
        package-1 package-2
FROM "${base}"
COPY --from=build /usr/local /usr/local
```
This will yield a container image with Conda packages `package-1`, `package-2` installed in a Conda environment at `/usr/local` which will be activated when entering the container, i.e., `docker run container-image-with-packages tool-from-package-1` will run `tool-from-package-1` in an activated environment.

(Optionally, one can instruct `create-env` to automatically `strip` binaries and remove files to slim down the created images. See `images/create-env/Dockerfile.test` for an example.)