### PR TITLE
create-env: Use entrypoint from /opt/create-env/

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-20.04
     env:
-      IMAGE_VERSION: '1.0.0'
+      IMAGE_VERSION: '1.0.1'
       VERSION: '4.9.2'
       IMAGE_NAME: create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -1,5 +1,5 @@
 # Use Debian instead of BusyBox base since Miniconda currently needs external zlib.
-FROM bioconda/base-glibc-debian-bash as build
+FROM quay.io/bioconda/base-glibc-debian-bash as build
 
 WORKDIR /tmp/work
 COPY install-conda print-env-activate create-env ./
@@ -9,14 +9,13 @@ ARG version='4.9.2'
 RUN ./install-conda "${version}" /opt/create-env
 
 
-FROM bioconda/base-glibc-busybox-bash
+FROM quay.io/bioconda/base-glibc-busybox-bash
 
 COPY --from=build /opt/create-env /opt/create-env
 # Copy (Bioconda-specific) Conda configuration created by the install-conda script.
 COPY --from=build /root/.condarc /root/
 
-RUN cp /opt/create-env/env-activate.sh /usr/local/ \
-    && \
+RUN \
     # Use a per-user config (instead of conda config --sys) for more flexibility.
     cp /root/.condarc /etc/skel/ \
     && \
@@ -30,5 +29,5 @@ RUN cp /opt/create-env/env-activate.sh /usr/local/ \
       >>   /etc/skel/.bashrc
 ENV ENV=/etc/profile.d/conda.sh
 
-ENTRYPOINT [ "/opt/create-env/bin/tini", "--", "/usr/local/env-execute" ]
+ENTRYPOINT [ "/opt/create-env/bin/tini", "--", "/opt/create-env/env-execute" ]
 CMD [ "bash" ]

--- a/images/create-env/Dockerfile.test
+++ b/images/create-env/Dockerfile.test
@@ -23,7 +23,7 @@ RUN /usr/local/env-execute \
 
 
 FROM "${base}" as build_conda
-RUN /usr/local/env-execute \
+RUN /opt/create-env/env-execute \
       create-env \
         --conda=mamba \
         --env-activate-args='--prefix-is-base' \


### PR DESCRIPTION
/usr/local gets "overwritten" (=bind-mounted) when building via mulled.
=> Make sure we use the "unique" `/opt/create-env/env-execute` path to avoid such overshadowing.