### PR TITLE
Add plain image version tag for create-env

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -29,6 +29,7 @@ jobs:
         image: ${{ env.IMAGE_NAME }}
         tags: >-
           latest
+          ${{ env.IMAGE_VERSION }}
           ${{ env.IMAGE_VERSION }}-${{ env.VERSION }}
         context: ./images/${{ env.IMAGE_NAME }}
         dockerfiles: |


### PR DESCRIPTION
Missed that on in gh-13 and gh-14.