### PR TITLE
Update base images to use Debian 10.8

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -85,6 +85,7 @@ jobs:
           )"
         ids="$( printf %s "${ids}" | sort -u )"
         for id in ${ids} ; do
+          podman history "${id}"
           buildah bud \
             --build-arg=base="${id}" \
             --file=Dockerfile.test \
@@ -143,6 +144,7 @@ jobs:
           )"
         ids="$( printf %s "${ids}" | sort -u )"
         for id in ${ids} ; do
+          podman history "${id}"
           buildah bud \
             --build-arg=base="${id}" \
             --file=Dockerfile.test \

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -17,13 +17,10 @@ jobs:
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '1.1.0'
+      IMAGE_VERSION: '2.0.0'
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.32.1'
-      # Use Debian 9 instead of newer one for now to get an image which is more
-      # similar to the larger base image (which does not use Debian 10+ because
-      # of increased size due to additional dependencies pulled in for OpenGL).
-      DEBIAN_VERSION: '9.13'
+      DEBIAN_VERSION: '10.8'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -17,12 +17,9 @@ jobs:
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '1.1.0'
+      IMAGE_VERSION: '2.0.0'
       IMAGE_NAME: base-glibc-debian-bash
-      # Use Debian 9 instead of newer one for now to get an image which is more
-      # similar to the larger base image (which does not use Debian 10+ because
-      # of increased size due to additional dependencies pulled in for OpenGL).
-      DEBIAN_VERSION: '9.13'
+      DEBIAN_VERSION: '10.8'
 
     steps:
     - uses: actions/checkout@v2

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -1,5 +1,5 @@
 ARG busybox_version=1.32.1
-ARG debian_version=9
+ARG debian_version=10.8
 
 # Don't use Debian's busybox package since it only provides a smaller subset of
 # BusyBox's functions (e.g., no administrative tools like adduser etc.).

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -1,4 +1,4 @@
-ARG debian_version=9.13
+ARG debian_version=10.8
 
 FROM "debian:${debian_version}-slim"
 
@@ -25,6 +25,15 @@ RUN apt-get update -qq \
     && \
     apt-get remove --yes \
       locales \
+    && \
+    # On Debian 10 (and 11) libgl1-mesa-glx pulls in libgl1-mesa-dri (which in
+    # turn has more heavy-weight dependencies). We leave these out of the image
+    # (by manually removing it from "Depends:" list) like we do with Debian 9.
+    sed -i \
+      '/^Depends:/ s/, libgl1-mesa-dri\>//g' \
+      /var/lib/dpkg/status \
+    && \
+    apt-get autoremove --yes \
     && \
     # Remove apt package lists.
     rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
The resulting container images are a little bit larger (just because the base files from Debian gained some size overall).