### PR TITLE
Customize create-env create command

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-20.04
     env:
-      IMAGE_VERSION: '1.0.2'
+      IMAGE_VERSION: '1.1.0'
       VERSION: '4.9.2'
       IMAGE_NAME: create-env
 

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -9,6 +9,7 @@ Use conda (or mamba via --conda=mamba) to create a Conda environment at PREFIX
 according to specifications given by CONDA_CREATE_ARGS.
 
   --conda=CONDA               text
+  --create-command=CREATE     text
   --env-activate-args=ARGS    text
   --env-activate-script=FILE  text
   --env-execute-script=FILE   text
@@ -18,6 +19,9 @@ end-of-help
       exit 0 ;;
     --conda=* )
       conda_impl="${arg#--conda=}"
+      shift ;;
+    --create-command=* )
+      create_command="${arg#--create-command=}"
       shift ;;
     --env-activate-args=* )
       env_activate_args="${arg#--env-activate-args=}"
@@ -58,6 +62,9 @@ prefix="${1%%/}"
 shift
 
 conda_impl="${conda_impl:-conda}"
+# Use --copy to cut links to package cache.
+# (Which is esp. important if --strip or --remove-files are used!)
+create_command="${create_command-create --copy}"
 env_activate_args="--prefix='${prefix}' ${env_activate_args-}"
 env_activate_file="${env_activate_file-"${prefix}/env-activate.sh"}"
 env_execute_file="${env_execute_file-"${prefix}/env-execute"}"
@@ -69,9 +76,7 @@ set +u
 eval "$( conda shell.posix activate base )"
 set -u
 
-# Use --copy to cut links to package cache.
-# (Which is esp. important if --strip or --remove-files are used!)
-${conda_impl} create --yes --copy --prefix="${prefix}" "${@}"
+CONDA_YES=1 ${conda_impl} ${create_command} --prefix="${prefix}" "${@}"
 
 if [ -n "${env_activate_file-}${env_execute_file-}" ] ; then
   activate_script="$(

--- a/images/create-env/install-conda
+++ b/images/create-env/install-conda
@@ -15,6 +15,9 @@ conda_install_prefix="${2}"
   . "${miniconda_boostrap_prefix}/etc/profile.d/conda.sh"
 
   # Install conda and some additional tools:
+  #  - python: pinned to 3.8 to avoid hitting
+  #    - https://github.com/conda/conda/issues/10490
+  #    - https://bugs.python.org/issue43517
   #  - tini: init program,
   #  - binutils, findutils: tools to strip down image/environment size,
   #  - mamba: alternative Conda package manager.
@@ -37,6 +40,8 @@ conda_install_prefix="${2}"
     --channel=conda-forge \
     \
     conda="${version}" \
+    \
+    python=3.8 \
     \
     tini \
     \


### PR DESCRIPTION
This allows someone to also use `conda env create` via `create-env --create-command='env create'`.