### PR TITLE
Use CONDA_ALWAYS_COPY=1 for create-env

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-20.04
     env:
-      IMAGE_VERSION: '1.1.0'
+      IMAGE_VERSION: '1.1.1'
       VERSION: '4.9.2'
       IMAGE_NAME: create-env
 

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -62,9 +62,7 @@ prefix="${1%%/}"
 shift
 
 conda_impl="${conda_impl:-conda}"
-# Use --copy to cut links to package cache.
-# (Which is esp. important if --strip or --remove-files are used!)
-create_command="${create_command-create --copy}"
+create_command="${create_command-create}"
 env_activate_args="--prefix='${prefix}' ${env_activate_args-}"
 env_activate_file="${env_activate_file-"${prefix}/env-activate.sh"}"
 env_execute_file="${env_execute_file-"${prefix}/env-execute"}"
@@ -76,7 +74,14 @@ set +u
 eval "$( conda shell.posix activate base )"
 set -u
 
-CONDA_YES=1 ${conda_impl} ${create_command} --prefix="${prefix}" "${@}"
+# Use CONDA_ALWAYS_COPY=1 to cut links to package cache.
+# (Which is esp. important if --strip or --remove-files are used!)
+CONDA_YES=1 \
+  CONDA_ALWAYS_COPY="${CONDA_ALWAYS_COPY:-1}" \
+  ${conda_impl} \
+  ${create_command} \
+  --prefix="${prefix}" \
+  "${@}"
 
 if [ -n "${env_activate_file-}${env_execute_file-}" ] ; then
   activate_script="$(


### PR DESCRIPTION
This way we don't need the explicit `--copy` parameter and as such we can ensure copying also for `create-env --conda='conda-env'`(`create-env --create-command='env create'`) since `conda-env create` does not support `--copy`.