### PR TITLE
create-env: Copy instead of hardlink licenses, exit on error

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build & Push
     runs-on: ubuntu-18.04
     env:
-      IMAGE_VERSION: '2.0.0'
+      IMAGE_VERSION: '2.1.0'
       VERSION: '4.9.2'
       IMAGE_NAME: create-env
 

--- a/images/create-env/CHANGELOG.md
+++ b/images/create-env/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## bioconda/create-env 2.1.0 (2021-04-14)
+
+### Changed
+
+- Copy instead of hardlink licenses, exit on error
+
+  Hardlink fails if copying spans cross devices (e.g., via bound volumes).
+
+
 ## bioconda/create-env 2.0.0 (2021-04-13)
 
 ### Changed

--- a/images/create-env/README.md
+++ b/images/create-env/README.md
@@ -36,7 +36,7 @@ Post-processing steps are triggered by arguments to `create-env`:
 
 ## Usage example:
 ```Dockerfile
-FROM quay.io/bioconda/create-env:2.0.0 as build
+FROM quay.io/bioconda/create-env:2.1.0 as build
 # Create an environment containing python=3.9 at /usr/local using mamba, strip
 # files and remove some less important files:
 RUN export CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 \
@@ -54,7 +54,7 @@ RUN export CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 \
 # The base image below (quay.io/bioconda/base-glibc-busybox-bash:2.0.0) defines
 # /usr/local/env-execute as the ENTRYPOINT so that created containers always
 # start in an activated environment.
-FROM quay.io/bioconda/base-glibc-busybox-bash:2.0.0 as target
+FROM quay.io/bioconda/base-glibc-busybox-bash:2.1.0 as target
 COPY --from=build /usr/local /usr/local
 
 FROM target as test

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -202,10 +202,11 @@ if [ -n "${licenses_path}" ] ; then
       find "${pkg_info}" \
         -maxdepth 1 \
         \( -name LICENSE.txt -o -name licenses \) \
-        -exec sh -c '
-          mkdir -p "${2}"
-          cp -flR "${1}" "${2}"
-        ' -- {} "${abs_licenses_path}/${pkg}" \; \
+        -exec sh -ec '
+          dest_dir="${1}" ; shift
+          mkdir -p "${dest_dir}"
+          cp -fR "${@}" "${dest_dir}/"
+        ' -- "${abs_licenses_path}/${pkg}" {} \+ \
         || {
           printf 'failed to copy licenses for %s\n' "${pkg}" 1>&2
           exit 1


### PR DESCRIPTION
Hardlink fails if copying spans cross devices (e.g., via bound volumes).