### PR TITLE
Add lightweight bot:* images for GitHub Actions

### DIFF
--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -1,0 +1,123 @@
+name: 'Build & Push: bot'
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - images/bot/**
+    - .github/workflows/bot.yaml
+  pull_request:
+    paths:
+    - images/bot/**
+    - .github/workflows/bot.yaml
+
+jobs:
+  build:
+    name: Build & Push
+    strategy:
+      matrix:
+        include:
+        - tag: comment
+          packages: ""
+        - tag: merge
+          packages: "anaconda-client skopeo"
+        - tag: update
+          packages: "git openssh"
+    runs-on: ubuntu-18.04
+    env:
+      IMAGE_NAME: bot
+      IMAGE_VERSION: '1.0.0'
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      id: buildah-build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: >-
+          ${{ matrix.tag }}
+          ${{ matrix.tag }}-${{ env.IMAGE_VERSION }}
+        context: ./images/${{ env.IMAGE_NAME }}
+        dockerfiles: |
+          ./images/${{ env.IMAGE_NAME }}/Dockerfile
+        build-args: |
+          packages=${{ matrix.packages }}
+
+    - name: Test
+      run: |
+        image='${{ steps.buildah-build.outputs.image }}'
+        ids="$(
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            buildah images --quiet --no-trunc "${image}:${tag}"
+          done
+          )"
+        ids="$( printf %s "${ids}" | sort -u )"
+        for id in ${ids} ; do
+          podman history "${id}"
+          buildah bud \
+            --build-arg=base="${id}" \
+            --file=Dockerfile.test \
+            'images/${{ env.IMAGE_NAME }}'
+        done
+        buildah rmi --prune || true
+
+    - name: Check Tags
+      run: |
+        # FIX upstream: Quay.io does not support immutable images currently.
+        #               => Try to use the REST API to check for duplicate tags.
+        respone="$(
+          curl -sL \
+            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
+          )"
+
+        existing_tags="$(
+          printf %s "${respone}" \
+            | jq -r '.images[].tags[]'
+          )" \
+          || {
+            printf %s\\n \
+              'Could not get list of image tags.' \
+              'Does the repository exist on Quay.io?' \
+              'Quay.io REST API response was:' \
+              "${respone}"
+            exit 1
+          }
+        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          if [ \! "${tag}" = '${{ matrix.tag }}' ] ; then
+            if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
+              printf 'Tag %s already exists!\n' "${tag}"
+              exit 1
+            fi
+          fi
+        done
+
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Push
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.buildah-build.outputs.image }}
+        tags: ${{ steps.buildah-build.outputs.tags }}
+        registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
+        username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
+        password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
+
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Test Pushed
+      run: |
+        image='${{ steps.buildah-build.outputs.image }}'
+        ids="$(
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            buildah images --quiet --no-trunc "${image}:${tag}"
+          done
+          )"
+        ids="$( printf %s "${ids}" | sort -u )"
+        for id in ${ids} ; do
+          podman history "${id}"
+          buildah bud \
+            --build-arg=base="${id}" \
+            --file=Dockerfile.test \
+            'images/${{ env.IMAGE_NAME }}'
+        done
+        buildah rmi --prune || true

--- a/images/bot/Dockerfile
+++ b/images/bot/Dockerfile
@@ -1,0 +1,85 @@
+ARG base=quay.io/bioconda/base-glibc-busybox-bash:2.1.0
+
+FROM quay.io/bioconda/create-env as build
+## If gettext pulls in libxml2, use one that doesn't bloat the image with ICU.
+#RUN . /opt/create-env/env-activate.sh \
+#    && \
+#    mamba install --yes curl conda-build patch \
+#    && \
+#    curl -L \
+#      https://github.com/conda-forge/libxml2-feedstock/archive/master.tar.gz \
+#      | tar -xzf- \
+#    && \
+#    cd libxml2-feedstock* \
+#    && \
+#    sed -i s/--with-icu/--without-icu/ recipe/build.sh \
+#    && \
+#    sed -i '/- icu\>/d' recipe/meta.yaml \
+#    && \
+#    conda-build -m .ci_support/linux_64_.yaml recipe/
+ARG packages=
+ARG python=3.8
+ARG prefix=/usr/local
+RUN . /opt/create-env/env-activate.sh && \
+    export CONDA_ADD_PIP_AS_PYTHON_DEPENDENCY=0 \
+    && \
+    create-env \
+        --conda=mamba \
+        --strip-files=\* \
+        --remove-paths=\*.a \
+        --remove-paths=\*.c \
+        --remove-paths=\*.pyc \
+        --remove-paths=\*.pyi \
+        --remove-paths=\*.pyx \
+        --remove-paths=\*.pyx \
+        --remove-paths=include/\* \
+        --remove-paths=share/doc/\* \
+        --remove-paths=share/man/\* \
+        --remove-paths=share/terminfo/\* \
+        --remove-paths=share/locale/\* \
+        --remove-paths=lib/python*/ensurepip/\* \
+        "${prefix}" \
+        --channel=local \
+        --channel=conda-forge \
+        --override-channels \
+        pip wheel setuptools \
+        python="${python}" \
+        aiohttp \
+        ca-certificates \
+        idna\<3 \
+        pyyaml \
+        ${packages} \
+    && \
+    # Remove tk since no tkinter & co. are needed.
+    conda remove \
+        --yes \
+        --force-remove \
+        --prefix="${prefix}" \
+        tk \
+    && \
+    # Get rid of Perl pulled in by Git.
+    # (Bot only uses non-Perl Git functionality => remove baggage.)
+    if conda list --prefix="${prefix}" | grep -q '^perl\s' ; then \
+        conda remove \
+            --yes \
+            --force-remove \
+            --prefix="${prefix}" \
+            perl \
+    ; fi
+# Install bioconda_bot.
+WORKDIR /tmp/bot
+COPY . ./
+RUN . "${prefix}/env-activate.sh" && \
+    pip wheel --no-deps . \
+    && \
+    pip install --no-deps --find-links . bioconda_bot
+# Remove pip (wheel setuptools) which are not needed during runtime.
+RUN . /opt/create-env/env-activate.sh && \
+    conda remove \
+        --yes \
+        --force-remove \
+        --prefix="${prefix}" \
+        pip wheel setuptools
+
+FROM "${base}"
+COPY --from=build /usr/local /usr/local

--- a/images/bot/Dockerfile.test
+++ b/images/bot/Dockerfile.test
@@ -1,0 +1,8 @@
+ARG base
+FROM "${base}"
+RUN . /usr/local/env-activate.sh && \
+    ls -lA /usr/local/conda-meta/*.json && \
+    bioconda-bot --help && \
+    bioconda-bot comment --help && \
+    bioconda-bot merge --help && \
+    bioconda-bot update --help

--- a/images/bot/pyproject.toml
+++ b/images/bot/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/images/bot/setup.cfg
+++ b/images/bot/setup.cfg
@@ -1,0 +1,20 @@
+[metadata]
+name = bioconda-bot
+version = 0.0.0
+
+[options]
+python_requires = >=3.8
+install_requires =
+    aiohttp
+    PyYaml
+
+packages = find:
+package_dir =
+    = src
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    bioconda-bot = bioconda_bot.cli:main

--- a/images/bot/src/bioconda_bot/cli.py
+++ b/images/bot/src/bioconda_bot/cli.py
@@ -1,0 +1,61 @@
+from logging import INFO, basicConfig
+
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from asyncio import run
+from typing import List, Optional
+
+
+def build_parser_comment(parser: ArgumentParser) -> None:
+    def run_command() -> None:
+        from .comment import main as main_
+
+        run(main_())
+
+    parser.set_defaults(run_command=run_command)
+
+
+def build_parser_merge(parser: ArgumentParser) -> None:
+    def run_command() -> None:
+        from .merge import main as main_
+
+        run(main_())
+
+    parser.set_defaults(run_command=run_command)
+
+
+def build_parser_update(parser: ArgumentParser) -> None:
+    def run_command() -> None:
+        from .update import main as main_
+
+        run(main_())
+
+    parser.set_defaults(run_command=run_command)
+
+
+def get_argument_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        prog="bioconda-bot",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    sub_parsers = parser.add_subparsers(
+        dest="command",
+        required=True,
+    )
+    for command_name, build_parser in (
+        ("comment", build_parser_comment),
+        ("merge", build_parser_merge),
+        ("update", build_parser_update),
+    ):
+        sub_parser = sub_parsers.add_parser(
+            command_name,
+            formatter_class=ArgumentDefaultsHelpFormatter,
+        )
+        build_parser(sub_parser)
+    return parser
+
+
+def main(args: Optional[List[str]] = None) -> None:
+    basicConfig(level=INFO)
+    parser = get_argument_parser()
+    parsed_args = parser.parse_args(args)
+    parsed_args.run_command()

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -1,0 +1,193 @@
+import logging
+import os
+import re
+import sys
+
+from aiohttp import ClientSession
+from yaml import safe_load
+
+from .common import (
+    async_exec,
+    fetch_pr_sha_artifacts,
+    get_pr_comment,
+    get_pr_info,
+    is_bioconda_member,
+    send_comment,
+)
+
+logger = logging.getLogger(__name__)
+log = logger.info
+
+
+# Given a PR and commit sha, post a comment with any artifacts
+async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> None:
+    artifacts = await fetch_pr_sha_artifacts(session, pr, sha)
+    nPackages = sum(1 for artifact in artifacts if artifact.endswith((".tar.bz2", "tar.gz")))
+
+    if nPackages > 0:
+        # If a package artifact is found, the accompanying repodata is the preceeding item in artifacts
+        comment = "Artifacts built on CircleCI are ready for inspection:\n\n"
+
+        # Table of packages and repodata.json
+        comment += "<details><summary>Package(s)</summary>\n\n"
+        comment += "Arch | Package | Repodata\n-----|---------|---------\n"
+        install_noarch = ""
+        install_linux = ""
+        install_osx = ""
+
+        for artifact in artifacts:
+            if not (package_match := re.match(r"^((.+)\/(.+)\/(.+\.tar\.bz2))$", artifact)):
+                continue
+            url, basedir, subdir, packageName = package_match.groups()
+            repo_url = "/".join([basedir, subdir, "repodata.json"])
+            conda_install_url = basedir
+
+            if subdir == "noarch":
+                comment += "noarch |"
+                install_noarch = (
+                    f"```\nconda install -c {conda_install_url} <package name>\n```\n"
+                )
+            elif subdir == "linux-64":
+                comment += "linux-64 |"
+                install_linux = (
+                    f"```\nconda install -c {conda_install_url} <package name>\n```\n"
+                )
+            else:
+                comment += "osx-64 |"
+                install_osx = f"```\nconda install -c {conda_install_url} <package name>\n```\n"
+            comment += f" [{packageName}]({url}) | [repodata.json]({repo_url})\n"
+
+        # Conda install examples
+        comment += "***\n\nYou may also use `conda` to install these:\n\n"
+        if install_noarch:
+            comment += f" * For packages on noarch:\n{install_noarch}"
+        if install_linux:
+            comment += f" * For packages on linux-64:\n{install_linux}"
+        if install_osx:
+            comment += f" * For packages on osx-64:\n{install_osx}"
+
+        comment += "***\n"
+        comment += "</details>\n"
+        # Table of containers
+        comment += "<details><summary>Container image(s)</summary>\n\n"
+        comment += "Package | Tag | Install with `docker`\n"
+        comment += "--------|-----|----------------------\n"
+
+        for artifact in artifacts:
+            if artifact.endswith(".tar.gz"):
+                image_name = artifact.split("/").pop()[: -len(".tar.gz")]
+                if "%3A" in image_name:
+                    package_name, tag = image_name.split("%3A", 1)
+                    comment += f"[{package_name}]({artifact}) | {tag} | "
+                    comment += f'<details><summary>show</summary>`curl -L "{artifact}" \\| gzip -dc \\| docker load`</details>\n'
+        comment += "</details>\n"
+    else:
+        comment = (
+            "No artifacts found on the most recent CircleCI build. "
+            "Either the build failed or the recipe was blacklisted/skipped."
+        )
+    await send_comment(session, pr, comment)
+
+
+# Post a comment on a given PR with its CircleCI artifacts
+async def artifact_checker(session: ClientSession, issue_number: int) -> None:
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}"
+    headers = {
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    pr_info = safe_load(res)
+
+    await make_artifact_comment(session, issue_number, pr_info["head"]["sha"])
+
+
+# Reposts a quoted message in a given issue/PR if the user isn't a bioconda member
+async def comment_reposter(session: ClientSession, user: str, pr: int, message: str) -> None:
+    if await is_bioconda_member(session, user):
+        log("Not reposting for %s", user)
+        return
+    log("Reposting for %s", user)
+    await send_comment(
+        session,
+        pr,
+        f"Reposting for @{user} to enable pings (courtesy of the BiocondaBot):\n\n> {message}",
+    )
+
+
+# Add the "Please review and merge" label to a PR
+async def add_pr_label(session: ClientSession, pr: int) -> None:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/issues/{pr}/labels"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    payload = {"labels": ["please review & merge"]}
+    async with session.post(url, headers=headers, json=payload) as response:
+        response.raise_for_status()
+
+
+async def gitter_message(session: ClientSession, msg: str) -> None:
+    token = os.environ["GITTER_TOKEN"]
+    room_id = "57f3b80cd73408ce4f2bba26"
+    url = f"https://api.gitter.im/v1/rooms/{room_id}/chatMessages"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    payload = {"text": msg}
+    log("Sending request to %s", url)
+    async with session.post(url, headers=headers, json=payload) as response:
+        response.raise_for_status()
+
+
+async def notify_ready(session: ClientSession, pr: int) -> None:
+    try:
+        await gitter_message(
+            session,
+            f"PR ready for review: https://github.com/bioconda/bioconda-recipes/pull/{pr}",
+        )
+    except Exception:
+        logger.exception("Posting to Gitter failed", exc_info=True)
+        # Do not die if we can't post to gitter!
+
+
+# This requires that a JOB_CONTEXT environment variable, which is made with `toJson(github)`
+async def main() -> None:
+    job_context, issue_number, original_comment = await get_pr_comment()
+    if issue_number is None or original_comment is None:
+        return
+
+    comment = original_comment.lower()
+    async with ClientSession() as session:
+        if comment.startswith(("@bioconda-bot", "@biocondabot")):
+            if "please update" in comment:
+                log("This should have been directly invoked via bioconda-bot-update")
+                from .update import update_from_master
+
+                await update_from_master(session, issue_number)
+            elif " hello" in comment:
+                await send_comment(session, issue_number, "Yes?")
+            elif " please fetch artifacts" in comment or " please fetch artefacts" in comment:
+                await artifact_checker(session, issue_number)
+            elif " please merge" in comment:
+                log("This should have been directly invoked via bioconda-bot-merge")
+                from .merge import merge_pr
+
+                await merge_pr(session, issue_number)
+            elif " please add label" in comment:
+                await add_pr_label(session, issue_number)
+                await notify_ready(session, issue_number)
+            # else:
+            #    # Methods in development can go below, flanked by checking who is running them
+            #      if job_context["actor"] != "dpryan79":
+            #          console.log("skipping")
+            #          sys.exit(0)
+        elif "@bioconda/" in comment:
+            await comment_reposter(
+                session, job_context["actor"], issue_number, original_comment
+            )

--- a/images/bot/src/bioconda_bot/common.py
+++ b/images/bot/src/bioconda_bot/common.py
@@ -1,0 +1,385 @@
+import logging
+import os
+import re
+import sys
+from asyncio import gather, sleep
+from asyncio.subprocess import create_subprocess_exec
+from pathlib import Path
+from shutil import which
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from aiohttp import ClientSession
+from yaml import safe_load
+
+logger = logging.getLogger(__name__)
+log = logger.info
+
+
+async def async_exec(
+    command: str, *arguments: str, env: Optional[Dict[str, str]] = None
+) -> None:
+    process = await create_subprocess_exec(command, *arguments, env=env)
+    return_code = await process.wait()
+    if return_code != 0:
+        raise RuntimeError(
+            f"Failed to execute {command} {arguments} (return code: {return_code})"
+        )
+
+
+# Post a comment on a given issue/PR with text in message
+async def send_comment(session: ClientSession, issue_number: int, message: str) -> None:
+    token = os.environ["BOT_TOKEN"]
+    url = (
+        f"https://api.github.com/repos/bioconda/bioconda-recipes/issues/{issue_number}/comments"
+    )
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    payload = {"body": message}
+    log("Sending comment: url=%s", url)
+    log("Sending comment: payload=%s", payload)
+    async with session.post(url, headers=headers, json=payload) as response:
+        status_code = response.status
+        log("the response code was %d", status_code)
+        if status_code < 200 or status_code > 202:
+            sys.exit(1)
+
+
+# Return true if a user is a member of bioconda
+async def is_bioconda_member(session: ClientSession, user: str) -> bool:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/orgs/bioconda/members/{user}"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    rc = 404
+    async with session.get(url, headers=headers) as response:
+        try:
+            response.raise_for_status()
+            rc = response.status
+        except:
+            # Do nothing, this just prevents things from crashing on 404
+            pass
+
+    return rc == 204
+
+
+# Fetch and return the JSON of a PR
+# This can be run to trigger a test merge
+async def get_pr_info(session: ClientSession, pr: int) -> Any:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{pr}"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    pr_info = safe_load(res)
+    return pr_info
+
+
+# Ensure there's at least one approval by a member
+async def approval_review(session: ClientSession, issue_number: int) -> bool:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}/reviews"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    reviews = safe_load(res)
+
+    approved_reviews = [review for review in reviews if review["state"] == "APPROVED"]
+    if not approved_reviews:
+        return False
+
+    # Ensure the review author is a member
+    return any(
+        gather(
+            *(
+                is_bioconda_member(session, review["user"]["login"])
+                for review in approved_reviews
+            )
+        )
+    )
+
+
+# Check the mergeable state of a PR
+async def check_is_mergeable(
+    session: ClientSession, issue_number: int, second_try: bool = False
+) -> bool:
+    token = os.environ["BOT_TOKEN"]
+    # Sleep a couple of seconds to allow the background process to finish
+    if second_try:
+        await sleep(3)
+
+    # PR info
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    pr_info = safe_load(res)
+
+    # We need mergeable == true and mergeable_state == clean, an approval by a member and
+    if pr_info.get("mergeable") is None and not second_try:
+        return await check_is_mergeable(session, issue_number, True)
+    elif (
+        pr_info.get("mergeable") is None
+        or not pr_info["mergeable"]
+        or pr_info["mergeable_state"] != "clean"
+    ):
+        return False
+
+    return await approval_review(session, issue_number)
+
+
+def parse_circle_ci_summary(summary: str) -> List[str]:
+    return re.findall(r"gh/bioconda/bioconda-recipes/(\d+)", summary)
+
+
+# Parse the summary string returned by github to get the CircleCI run ID
+# Given a CircleCI run ID, return a list of its tarball artifacts
+async def fetch_artifacts(session: ClientSession, circle_ci_id: str) -> Set[str]:
+    url = f"https://circleci.com/api/v1.1/project/github/bioconda/bioconda-recipes/{circle_ci_id}/artifacts"
+    log("contacting circleci %s", url)
+    async with session.get(url) as response:
+        # Sometimes we get a 301 error, so there are no longer artifacts available
+        if response.status == 301:
+            return set()
+        res = await response.text()
+
+    if len(res) < 3:
+        return set()
+
+    res = res.replace("(", "[").replace(")", "]")
+    res = res.replace("} ", "}, ")
+    res = res.replace(":node-index", '"node-index":')
+    res = res.replace(":path", '"path":')
+    res = res.replace(":pretty-path", '"pretty-path":')
+    res = res.replace(":url", '"url":')
+    res_object = safe_load(res)
+    artifacts = {
+        artifact["url"]
+        for artifact in res_object
+        if artifact["url"].endswith(
+            (
+                ".tar.gz",
+                ".tar.bz2",
+                "/repodata.json",
+            )
+        )
+    }
+    return artifacts
+
+
+# Given a PR and commit sha, fetch a list of the artifacts
+async def fetch_pr_sha_artifacts(session: ClientSession, pr: int, sha: str) -> List[str]:
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/commits/{sha}/check-runs"
+    artifacts: List[str] = []
+
+    headers = {
+        "User-Agent": "BiocondaCommentResponder",
+        "Accept": "application/vnd.github.antiope-preview+json",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    check_runs = safe_load(res)
+
+    for check_run in check_runs["check_runs"]:
+        if check_run["output"]["title"] == "Workflow: bioconda-test":
+            # The circleci IDs are embedded in a string in output:summary
+            circle_ci_ids = parse_circle_ci_summary(check_run["output"]["summary"])
+            for item in circle_ci_ids:
+                artifact = await fetch_artifacts(session, item)
+                artifacts.extend(artifact)
+    return artifacts
+
+
+# Ensure uploaded containers are in repos that have public visibility
+async def toggle_visibility(session: ClientSession, container_repo: str) -> None:
+    url = f"https://quay.io/api/v1/repository/biocontainers/{container_repo}/changevisibility"
+    QUAY_OAUTH_TOKEN = os.environ["QUAY_OAUTH_TOKEN"]
+    headers = {
+        "Authorization": f"Bearer {QUAY_OAUTH_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    body = {"visibility": "public"}
+    rc = 0
+    try:
+        async with session.post(url, headers=headers, json=body) as response:
+            rc = response.status
+    except:
+        # Do nothing
+        pass
+    log("Trying to toggle visibility (%s) returned %d", url, rc)
+
+
+# Download an artifact from CircleCI, rename and upload it
+async def download_and_upload(session: ClientSession, x: str) -> None:
+    basename = x.split("/").pop()
+    # the tarball needs a regular name without :, the container needs pkg:tag
+    image_name = basename.replace("%3A", ":").replace("\n", "").replace(".tar.gz", "")
+    file_name = basename.replace("%3A", "_").replace("\n", "")
+
+    async with session.get(x) as response:
+        with open(file_name, "wb") as file:
+            logged = 0
+            loaded = 0
+            while chunk := await response.content.read(256 * 1024):
+                file.write(chunk)
+                loaded += len(chunk)
+                if loaded - logged >= 50 * 1024 ** 2:
+                    log("Downloaded %.0f MiB: %s", max(1, loaded / 1024 ** 2), x)
+                    logged = loaded
+            log("Downloaded %.0f MiB: %s", max(1, loaded / 1024 ** 2), x)
+
+    if x.endswith(".gz"):
+        # Container
+        log("uploading with skopeo: %s", file_name)
+        # This can fail, retry with 5 second delays
+        count = 0
+        maxTries = 5
+        success = False
+        QUAY_LOGIN = os.environ["QUAY_LOGIN"]
+        env = os.environ.copy()
+        # TODO: Fix skopeo package to find certificates on its own.
+        skopeo_path = which("skopeo")
+        if not skopeo_path:
+            raise RuntimeError("skopeo not found")
+        env["SSL_CERT_DIR"] = str(Path(skopeo_path).parents[1].joinpath("ssl"))
+        while count < maxTries:
+            try:
+                await async_exec(
+                    "skopeo",
+                    "--command-timeout",
+                    "600s",
+                    "copy",
+                    f"docker-archive:{file_name}",
+                    f"docker://quay.io/biocontainers/{image_name}",
+                    "--dest-creds",
+                    QUAY_LOGIN,
+                    env=env,
+                )
+                success = True
+                break
+            except:
+                count += 1
+                if count == maxTries:
+                    raise
+            await sleep(5)
+        if success:
+            await toggle_visibility(session, basename.split("%3A")[0])
+    elif x.endswith(".bz2"):
+        # Package
+        log("uploading package")
+        ANACONDA_TOKEN = os.environ["ANACONDA_TOKEN"]
+        await async_exec("anaconda", "-t", ANACONDA_TOKEN, "upload", file_name, "--force")
+
+    log("cleaning up")
+    os.remove(file_name)
+
+
+# Upload artifacts to quay.io and anaconda, return the commit sha
+# Only call this for mergeable PRs!
+async def upload_artifacts(session: ClientSession, pr: int) -> str:
+    # Get last sha
+    pr_info = await get_pr_info(session, pr)
+    sha: str = pr_info["head"]["sha"]
+
+    # Fetch the artifacts
+    artifacts = await fetch_pr_sha_artifacts(session, pr, sha)
+    artifacts = [artifact for artifact in artifacts if artifact.endswith((".gz", ".bz2"))]
+    assert artifacts
+
+    # Download/upload Artifacts
+    for artifact in artifacts:
+        await download_and_upload(session, artifact)
+
+    return sha
+
+
+# Assume we have no more than 250 commits in a PR, which is probably reasonable in most cases
+async def get_pr_commit_message(session: ClientSession, issue_number: int) -> str:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}/commits"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    commits = safe_load(res)
+    message = "".join(f" * {commit['commit']['message']}\n" for commit in reversed(commits))
+    return message
+
+
+# Merge a PR
+async def merge_pr(session: ClientSession, pr: int) -> None:
+    token = os.environ["BOT_TOKEN"]
+    await send_comment(
+        session,
+        pr,
+        "I will attempt to upload artifacts and merge this PR. This may take some time, please have patience.",
+    )
+
+    try:
+        mergeable = await check_is_mergeable(session, pr)
+        log("mergeable state of %s is %s", pr, mergeable)
+        if not mergeable:
+            await send_comment(session, pr, "Sorry, this PR cannot be merged at this time.")
+        else:
+            log("uploading artifacts")
+            sha = await upload_artifacts(session, pr)
+            log("artifacts uploaded")
+
+            # Carry over last 250 commit messages
+            msg = await get_pr_commit_message(session, pr)
+
+            # Hit merge
+            url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{pr}/merge"
+            headers = {
+                "Authorization": f"token {token}",
+                "User-Agent": "BiocondaCommentResponder",
+            }
+            payload = {
+                "sha": sha,
+                "commit_title": f"[ci skip] Merge PR {pr}",
+                "commit_message": f"Merge PR #{pr}, commits were: \n{msg}",
+                "merge_method": "squash",
+            }
+            log("Putting merge commit")
+            async with session.put(url, headers=headers, json=payload) as response:
+                rc = response.status
+            log("body %s", payload)
+            log("merge_pr the response code was %s", rc)
+    except:
+        await send_comment(
+            session,
+            pr,
+            "I received an error uploading the build artifacts or merging the PR!",
+        )
+        logger.exception("Upload failed", exc_info=True)
+
+
+async def get_pr_comment() -> Tuple[Any, Optional[int], Optional[str]]:
+    job_context = safe_load(os.environ["JOB_CONTEXT"])
+    log("%s", job_context)
+    if job_context["event"]["issue"].get("pull_request") is None:
+        return job_context, None, None
+    issue_number = job_context["event"]["issue"]["number"]
+
+    original_comment = job_context["event"]["comment"]["body"]
+    log("the comment is: %s", original_comment)
+    return job_context, issue_number, original_comment

--- a/images/bot/src/bioconda_bot/merge.py
+++ b/images/bot/src/bioconda_bot/merge.py
@@ -1,0 +1,269 @@
+import logging
+import os
+import re
+import sys
+from asyncio import gather, sleep
+from asyncio.subprocess import create_subprocess_exec
+from pathlib import Path
+from shutil import which
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from aiohttp import ClientSession
+from yaml import safe_load
+
+from .common import (
+    async_exec,
+    fetch_pr_sha_artifacts,
+    get_pr_comment,
+    get_pr_info,
+    is_bioconda_member,
+    send_comment,
+)
+
+logger = logging.getLogger(__name__)
+log = logger.info
+
+
+# Ensure there's at least one approval by a member
+async def approval_review(session: ClientSession, issue_number: int) -> bool:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}/reviews"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    reviews = safe_load(res)
+
+    approved_reviews = [review for review in reviews if review["state"] == "APPROVED"]
+    if not approved_reviews:
+        return False
+
+    # Ensure the review author is a member
+    return any(
+        gather(
+            *(
+                is_bioconda_member(session, review["user"]["login"])
+                for review in approved_reviews
+            )
+        )
+    )
+
+
+# Check the mergeable state of a PR
+async def check_is_mergeable(
+    session: ClientSession, issue_number: int, second_try: bool = False
+) -> bool:
+    token = os.environ["BOT_TOKEN"]
+    # Sleep a couple of seconds to allow the background process to finish
+    if second_try:
+        await sleep(3)
+
+    # PR info
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    pr_info = safe_load(res)
+
+    # We need mergeable == true and mergeable_state == clean, an approval by a member and
+    if pr_info.get("mergeable") is None and not second_try:
+        return await check_is_mergeable(session, issue_number, True)
+    elif (
+        pr_info.get("mergeable") is None
+        or not pr_info["mergeable"]
+        or pr_info["mergeable_state"] != "clean"
+    ):
+        return False
+
+    return await approval_review(session, issue_number)
+
+
+def parse_circle_ci_summary(summary: str) -> List[str]:
+    return re.findall(r"gh/bioconda/bioconda-recipes/(\d+)", summary)
+
+
+# Ensure uploaded containers are in repos that have public visibility
+async def toggle_visibility(session: ClientSession, container_repo: str) -> None:
+    url = f"https://quay.io/api/v1/repository/biocontainers/{container_repo}/changevisibility"
+    QUAY_OAUTH_TOKEN = os.environ["QUAY_OAUTH_TOKEN"]
+    headers = {
+        "Authorization": f"Bearer {QUAY_OAUTH_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    body = {"visibility": "public"}
+    rc = 0
+    try:
+        async with session.post(url, headers=headers, json=body) as response:
+            rc = response.status
+    except:
+        # Do nothing
+        pass
+    log("Trying to toggle visibility (%s) returned %d", url, rc)
+
+
+# Download an artifact from CircleCI, rename and upload it
+async def download_and_upload(session: ClientSession, x: str) -> None:
+    basename = x.split("/").pop()
+    # the tarball needs a regular name without :, the container needs pkg:tag
+    image_name = basename.replace("%3A", ":").replace("\n", "").replace(".tar.gz", "")
+    file_name = basename.replace("%3A", "_").replace("\n", "")
+
+    async with session.get(x) as response:
+        with open(file_name, "wb") as file:
+            logged = 0
+            loaded = 0
+            while chunk := await response.content.read(256 * 1024):
+                file.write(chunk)
+                loaded += len(chunk)
+                if loaded - logged >= 50 * 1024 ** 2:
+                    log("Downloaded %.0f MiB: %s", max(1, loaded / 1024 ** 2), x)
+                    logged = loaded
+            log("Downloaded %.0f MiB: %s", max(1, loaded / 1024 ** 2), x)
+
+    if x.endswith(".gz"):
+        # Container
+        log("uploading with skopeo: %s", file_name)
+        # This can fail, retry with 5 second delays
+        count = 0
+        maxTries = 5
+        success = False
+        QUAY_LOGIN = os.environ["QUAY_LOGIN"]
+        env = os.environ.copy()
+        # TODO: Fix skopeo package to find certificates on its own.
+        skopeo_path = which("skopeo")
+        if not skopeo_path:
+            raise RuntimeError("skopeo not found")
+        env["SSL_CERT_DIR"] = str(Path(skopeo_path).parents[1].joinpath("ssl"))
+        while count < maxTries:
+            try:
+                await async_exec(
+                    "skopeo",
+                    "--command-timeout",
+                    "600s",
+                    "copy",
+                    f"docker-archive:{file_name}",
+                    f"docker://quay.io/biocontainers/{image_name}",
+                    "--dest-creds",
+                    QUAY_LOGIN,
+                    env=env,
+                )
+                success = True
+                break
+            except:
+                count += 1
+                if count == maxTries:
+                    raise
+            await sleep(5)
+        if success:
+            await toggle_visibility(session, basename.split("%3A")[0])
+    elif x.endswith(".bz2"):
+        # Package
+        log("uploading package")
+        ANACONDA_TOKEN = os.environ["ANACONDA_TOKEN"]
+        await async_exec("anaconda", "-t", ANACONDA_TOKEN, "upload", file_name, "--force")
+
+    log("cleaning up")
+    os.remove(file_name)
+
+
+# Upload artifacts to quay.io and anaconda, return the commit sha
+# Only call this for mergeable PRs!
+async def upload_artifacts(session: ClientSession, pr: int) -> str:
+    # Get last sha
+    pr_info = await get_pr_info(session, pr)
+    sha: str = pr_info["head"]["sha"]
+
+    # Fetch the artifacts
+    artifacts = await fetch_pr_sha_artifacts(session, pr, sha)
+    artifacts = [artifact for artifact in artifacts if artifact.endswith((".gz", ".bz2"))]
+    assert artifacts
+
+    # Download/upload Artifacts
+    for artifact in artifacts:
+        await download_and_upload(session, artifact)
+
+    return sha
+
+
+# Assume we have no more than 250 commits in a PR, which is probably reasonable in most cases
+async def get_pr_commit_message(session: ClientSession, issue_number: int) -> str:
+    token = os.environ["BOT_TOKEN"]
+    url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{issue_number}/commits"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "BiocondaCommentResponder",
+    }
+    async with session.get(url, headers=headers) as response:
+        response.raise_for_status()
+        res = await response.text()
+    commits = safe_load(res)
+    message = "".join(f" * {commit['commit']['message']}\n" for commit in reversed(commits))
+    return message
+
+
+# Merge a PR
+async def merge_pr(session: ClientSession, pr: int) -> None:
+    token = os.environ["BOT_TOKEN"]
+    await send_comment(
+        session,
+        pr,
+        "I will attempt to upload artifacts and merge this PR. This may take some time, please have patience.",
+    )
+
+    try:
+        mergeable = await check_is_mergeable(session, pr)
+        log("mergeable state of %s is %s", pr, mergeable)
+        if not mergeable:
+            await send_comment(session, pr, "Sorry, this PR cannot be merged at this time.")
+        else:
+            log("uploading artifacts")
+            sha = await upload_artifacts(session, pr)
+            log("artifacts uploaded")
+
+            # Carry over last 250 commit messages
+            msg = await get_pr_commit_message(session, pr)
+
+            # Hit merge
+            url = f"https://api.github.com/repos/bioconda/bioconda-recipes/pulls/{pr}/merge"
+            headers = {
+                "Authorization": f"token {token}",
+                "User-Agent": "BiocondaCommentResponder",
+            }
+            payload = {
+                "sha": sha,
+                "commit_title": f"[ci skip] Merge PR {pr}",
+                "commit_message": f"Merge PR #{pr}, commits were: \n{msg}",
+                "merge_method": "squash",
+            }
+            log("Putting merge commit")
+            async with session.put(url, headers=headers, json=payload) as response:
+                rc = response.status
+            log("body %s", payload)
+            log("merge_pr the response code was %s", rc)
+    except:
+        await send_comment(
+            session,
+            pr,
+            "I received an error uploading the build artifacts or merging the PR!",
+        )
+        logger.exception("Upload failed", exc_info=True)
+
+
+# This requires that a JOB_CONTEXT environment variable, which is made with `toJson(github)`
+async def main() -> None:
+    job_context, issue_number, original_comment = await get_pr_comment()
+    if issue_number is None or original_comment is None:
+        return
+
+    comment = original_comment.lower()
+    if comment.startswith(("@bioconda-bot", "@biocondabot")):
+        if " please merge" in comment:
+            async with ClientSession() as session:
+                await merge_pr(session, issue_number)

--- a/images/bot/src/bioconda_bot/update.py
+++ b/images/bot/src/bioconda_bot/update.py
@@ -1,0 +1,76 @@
+import logging
+import sys
+
+from aiohttp import ClientSession
+
+from .common import (
+    async_exec,
+    get_pr_comment,
+    get_pr_info,
+    send_comment,
+)
+
+logger = logging.getLogger(__name__)
+log = logger.info
+
+
+# Update a branch from upstream master, this should be run in a try/catch
+async def update_from_master_runner(session: ClientSession, pr: int) -> None:
+    async def git(*args: str) -> None:
+        return await async_exec("git", *args)
+
+    # Setup git, otherwise we can't push
+    await git("config", "--global", "user.email", "biocondabot@gmail.com")
+    await git("config", "--global", "user.name", "BiocondaBot")
+
+    pr_info = await get_pr_info(session, pr)
+    remote_branch = pr_info["head"]["ref"]
+    remote_repo = pr_info["head"]["repo"]["full_name"]
+
+    max_depth = 2000
+    # Clone
+    await git(
+        "clone",
+        f"--depth={max_depth}",
+        f"--branch={remote_branch}",
+        f"git@github.com:{remote_repo}.git",
+        "bioconda-recipes",
+    )
+
+    async def git_c(*args: str) -> None:
+        return await git("-C", "bioconda-recipes", *args)
+
+    # Add/pull upstream
+    await git_c("remote", "add", "upstream", "https://github.com/bioconda/bioconda-recipes")
+    await git_c("fetch", f"--depth={max_depth}", "upstream", "master")
+
+    # Merge
+    await git_c("merge", "upstream/master")
+
+    await git_c("push")
+
+
+# Merge the upstream master branch into a PR branch, leave a message on error
+async def update_from_master(session: ClientSession, pr: int) -> None:
+    try:
+        await update_from_master_runner(session, pr)
+    except Exception as e:
+        await send_comment(
+            session,
+            pr,
+            "I encountered an error updating your PR branch. You can report this to bioconda/core if you'd like.\n-The Bot",
+        )
+        sys.exit(1)
+
+
+# This requires that a JOB_CONTEXT environment variable, which is made with `toJson(github)`
+async def main() -> None:
+    job_context, issue_number, original_comment = await get_pr_comment()
+    if issue_number is None or original_comment is None:
+        return
+
+    comment = original_comment.lower()
+    if comment.startswith(("@bioconda-bot", "@biocondabot")):
+        if "please update" in comment:
+            async with ClientSession() as session:
+                await update_from_master(session, issue_number)


### PR DESCRIPTION
This initial version should be functionally identical to `bioconda-recipes-issue-responder` but create smaller, purpose-bound containers.