### PR TITLE
Fix conda instructions in comment

### DIFF
--- a/images/bioconda-recipes-issue-responder/issue-responder
+++ b/images/bioconda-recipes-issue-responder/issue-responder
@@ -168,7 +168,7 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
 
         # Conda install examples
         comment += "***\n\nYou may also use `conda` to install these after downloading and extracting the appropriate zip file. From the LinuxArtifacts or OSXArtifacts directories:\n\n"
-        comment += "```conda install -c packages <package name>\n```\n"
+        comment += "```conda install -c ./packages <package name>\n```\n"
 
         # Table of containers
         comment += "***\n\nDocker image(s) built (images are in the LinuxArtifacts zip file above):\n\n"

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -57,7 +57,7 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
 
         # Conda install examples
         comment += "***\n\nYou may also use `conda` to install these after downloading and extracting the appropriate zip file. From the LinuxArtifacts or OSXArtifacts directories:\n\n"
-        comment += "```\nconda install -c packages <package name>\n```\n"
+        comment += "```\nconda install -c ./packages <package name>\n```\n"
 
         # Table of containers
         comment += "***\n\nDocker image(s) built (images are in the LinuxArtifacts zip file above):\n\n"


### PR DESCRIPTION
At least for conda 4.14.0, `conda install -c packages` fails as `packages` is not a known channel, while `conda install -c ./packages` works as expected.