### PR TITLE
create-env: Use build-env's conda, mamba versions

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -14,14 +14,21 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
-      IMAGE_VERSION: '2.1.0'
-      VERSION: '4.9.2'
+      IMAGE_VERSION: '2.2.0'
       IMAGE_NAME: create-env
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Prepare
+      id: prepare
+      run: |
+        curl -sSL \
+          'https://raw.githubusercontent.com/bioconda/bioconda-common/master/common.sh' \
+          | sed -n \
+            's/BIOCONDA_UTILS_TAG=v/::set-output name=bioconda_utils_version::/p'
 
     - name: Build
       id: buildah-build
@@ -31,12 +38,11 @@ jobs:
         tags: >-
           latest
           ${{ env.IMAGE_VERSION }}
-          ${{ env.IMAGE_VERSION }}-${{ env.VERSION }}
         context: ./images/${{ env.IMAGE_NAME }}
         dockerfiles: |
           ./images/${{ env.IMAGE_NAME }}/Dockerfile
         build-args: |
-          version=${{ env.VERSION }}
+          bioconda_utils_version=${{ steps.prepare.outputs.bioconda_utils_version }}
 
     - name: Test
       run: |

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -66,30 +66,35 @@ jobs:
       run: |
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
-        respone="$(
-          curl -sL \
-            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
-          )"
-
-        existing_tags="$(
-          printf %s "${respone}" \
-            | jq -r '.images[].tags[]'
-          )" \
-          || {
-            printf %s\\n \
-              'Could not get list of image tags.' \
-              'Does the repository exist on Quay.io?' \
-              'Quay.io REST API response was:' \
-              "${respone}"
-            exit 1
-          }
-        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
-          if [ \! "${tag}" = latest ] ; then
-            if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
-              printf 'Tag %s already exists!\n' "${tag}"
+        page=0
+        has_additional='true'
+        while [ "${has_additional}" = 'true' ] ; do
+          page="$(( page + 1 ))"
+          respone="$(
+            curl -sL \
+              'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/tag?limit=100&page='"${page}"
+            )"
+          has_additional="$( printf %s "${respone}" | jq -r '.has_additional' )"
+          existing_tags="$(
+            printf %s "${respone}" \
+              | jq -r '.tags[]|.name'
+            )" \
+            || {
+              >&2 printf %s\\n \
+                'Could not get list of image tags.' \
+                'Does the repository exist on Quay.io?' \
+                'Quay.io REST API response was:' \
+                "${respone}"
               exit 1
+            }
+          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+            if [ \! "${tag}" = latest ] ; then
+              if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
+                >&2 printf 'Tag %s already exists!\n' "${tag}"
+                exit 1
+              fi
             fi
-          fi
+          done
         done
 
     - if: ${{ github.ref == 'refs/heads/main' }}

--- a/images/create-env/CHANGELOG.md
+++ b/images/create-env/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## bioconda/create-env 2.2.0 (2022-10-14)
+
+### Changed
+
+- Use the exact conda, mamba versions as used in bioconda-recipes' builds.
+
+
 ## bioconda/create-env 2.1.0 (2021-04-14)
 
 ### Changed

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -1,12 +1,21 @@
+# Use the exact conda, mamba versions as used in bioconda-recipes' builds.
+ARG bioconda_utils_version='1.1.3'
+FROM quay.io/bioconda/bioconda-utils-build-env-cos7:${bioconda_utils_version} as bioconda-build-env
+RUN /opt/conda/bin/conda list \
+      --export '^(conda|mamba)$' \
+      | sed -n 's/=[^=]*$//p' \
+      > /tmp/requirements.txt
+
+
 # Use Debian instead of BusyBox base since Miniconda currently needs external zlib.
 FROM quay.io/bioconda/base-glibc-debian-bash as build
 
 WORKDIR /tmp/work
+COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
 ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh ./miniconda.sh
 
-ARG version='4.9.2'
-RUN ./install-conda "${version}" /opt/create-env
+RUN ./install-conda ./requirements.txt /opt/create-env
 
 
 FROM quay.io/bioconda/base-glibc-busybox-bash

--- a/images/create-env/install-conda
+++ b/images/create-env/install-conda
@@ -1,6 +1,6 @@
 #! /bin/bash -eu
 
-version="${1}"
+requirements_file="${1}"
 conda_install_prefix="${2}"
 
 # Install a bootstrap Miniconda installation.
@@ -14,13 +14,9 @@ miniconda_boostrap_prefix="$( pwd )/miniconda"
   # Install the base Conda installation.
   . "${miniconda_boostrap_prefix}/etc/profile.d/conda.sh"
 
-  # Install conda and some additional tools:
-  #  - python: pinned to 3.8 to avoid hitting
-  #    - https://github.com/conda/conda/issues/10490
-  #    - https://bugs.python.org/issue43517
+  # Install conda, mamba and some additional tools:
   #  - tini: init program,
   #  - binutils, findutils: tools to strip down image/environment size,
-  #  - mamba: alternative Conda package manager.
 
   # Only need `strip` executable from binutils. Other binaries from the package
   # and especially the "sysroot" dependency is only bloat for this container
@@ -39,16 +35,12 @@ miniconda_boostrap_prefix="$( pwd )/miniconda"
     --prefix="${conda_install_prefix}" \
     --channel=conda-forge \
     \
-    conda="${version}" \
-    \
-    python=3.8 \
+    --file="${requirements_file}" \
     \
     tini \
     \
     libgcc-ng \
     findutils \
-    \
-    mamba \
     ;
 
   mv \
@@ -109,3 +101,8 @@ conda config \
 conda list --name=base
 conda info --all
 mamba --version
+# Make sure we have the requested conda, mamba versions installed.
+conda list \
+  --export '^(conda|mamba)$' \
+  | sed -n 's/=[^=]*$//p' \
+  | diff "${requirements_file}" -


### PR DESCRIPTION
Use the exact conda, mamba versions as used in bioconda-recipes' builds.