### PR TITLE
Patch - small fix on merge command and quay toggle visibility

### DIFF
--- a/images/bot/src/bioconda_bot/merge.py
+++ b/images/bot/src/bioconda_bot/merge.py
@@ -244,7 +244,7 @@ async def upload_image(session: ClientSession, zf: ZipFile, e: ZipInfo):
                 raise
         await sleep(5)
     if success:
-        await toggle_visibility(session, basename.split("%3A")[0])
+        await toggle_visibility(session, basename.split(":")[0])
 
     log("cleaning up")
     os.remove(newFName)

--- a/images/bot/src/bioconda_bot/merge.py
+++ b/images/bot/src/bioconda_bot/merge.py
@@ -244,7 +244,7 @@ async def upload_image(session: ClientSession, zf: ZipFile, e: ZipInfo):
                 raise
         await sleep(5)
     if success:
-        await toggle_visibility(session, basename.split(":")[0])
+        await toggle_visibility(session, basename.split(":")[0] if ":" in basename else basename.split("%3A")[0])
 
     log("cleaning up")
     os.remove(newFName)


### PR DESCRIPTION
Super minor correction, at some point it looks like "%3A" became the actual ":". 

Here's a few examples: 

https://github.com/bioconda/bioconda-recipes/actions/runs/3961359152/jobs/6786688097#step:3:425
https://github.com/bioconda/bioconda-recipes/actions/runs/3950723167/jobs/6763645252#step:3:783
https://github.com/bioconda/bioconda-recipes/actions/runs/3944470798/jobs/6750412771#step:3:540

I think as a small patch this will get things moving again, and I can work on a way to periodically check for private repos