### PR TITLE
Make base images multiarch

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Test
       run: |
-        image='${{ env.IMAGE_NAME }}'
+        image='${{ steps.build.outputs.image }}'
         ids="$(
           for tag in ${{ steps.calculate.outputs.tags }} ; do
             buildah images --quiet --no-trunc "${image}:${tag}"

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '2.1.0'
+      IMAGE_VERSION: '3.0.0'
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.32.1'
       DEBIAN_VERSION: '10.9'
@@ -26,8 +26,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Build
-      id: buildah-build
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+
+    - name: Calculate tags and labels
+      id: calculate
       run: |
         set -xeu
         cd 'images/${{ env.IMAGE_NAME }}'
@@ -49,11 +54,12 @@ jobs:
         bash="$( run bash --version | sed '1!d' )"
         buildah rm "${container}"
 
-        container="$( buildah from "${image_id}" )"
-        buildah config --label=glibc="${glibc}" "${container}"
-        buildah config --label=busybox="${busybox}" "${container}"
-        buildah config --label=deb-list="${deb_list}" "${container}"
-        buildah config --label=pkg-list="${pkg_list}" "${container}"
+        labels="
+          glibc="${glibc}"
+          busybox="${busybox}"
+          deb-list="${deb_list}"
+          pkg-list="${pkg_list}"
+        "
 
         glibc_version="$( printf %s "${glibc}" | sed -E 's/.*version ([0-9.]*[0-9]).*/\1/' )"
         busybox_version="$( printf %s "${busybox}" | sed -E '1 s/.*v([0-9.]*[0-9]).*/\1/' )"
@@ -64,23 +70,29 @@ jobs:
           latest
         "
 
-        image_id="$( buildah commit "${container}" )"
-        buildah rm "${container}"
-        image_name='${{ env.IMAGE_NAME }}'
+        echo "tags=$( echo ${tags} )" >> $GITHUB_OUTPUT
+        echo "labels=$( echo ${labels} )" >> $GITHUB_OUTPUT
 
-        for tag in ${tags} ; do
-          buildah tag "${image_id}" \
-            "${image_name}":"${tag}"
-        done
-
-        echo "::set-output name=image::${image_name}"
-        echo "::set-output name=tags::$( echo ${tags} )"
+    - name: Build multiarch image
+      id: build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ steps.calculate.outputs.tags }}
+        labels: ${{ steps.calculate.outputs.labels }}
+        archs: amd64,arm64
+        build-args: |
+          busybox_version=${{ env.BUSYBOX_VERSION }}
+          debian_version=${{ env.DEBIAN_VERSION }}
+        context: ./images/${{ env.IMAGE_NAME }}
+        containerfiles: |
+          ./images/${{ env.IMAGE_NAME }}/Dockerfile
 
     - name: Test
       run: |
-        image='${{ steps.buildah-build.outputs.image }}'
+        image='${{ env.IMAGE_NAME }}'
         ids="$(
-          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          for tag in ${{ steps.calculate.outputs.tags }} ; do
             buildah images --quiet --no-trunc "${image}:${tag}"
           done
           )"
@@ -99,8 +111,8 @@ jobs:
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
         respone="$(
-          curl -sL \
-            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
+          curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
+            'https://quay.io/api/v1/repository/bioconda/${{ steps.build.outputs.image }}/image'
           )"
 
         existing_tags="$(
@@ -115,7 +127,7 @@ jobs:
               "${respone}"
             exit 1
           }
-        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+        for tag in ${{ steps.calculate.outputs.tags }} ; do
           if [ \! "${tag}" = latest ] ; then
             if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
               printf 'Tag %s already exists!\n' "${tag}"
@@ -128,8 +140,8 @@ jobs:
       name: Push
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.buildah-build.outputs.image }}
-        tags: ${{ steps.buildah-build.outputs.tags }}
+        image: ${{ steps.build.outputs.image }}
+        tags: ${{ steps.calculate.outputs.tags }}
         registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
         username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
         password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
@@ -137,9 +149,9 @@ jobs:
     - if: ${{ github.ref == 'refs/heads/main' }}
       name: Test Pushed
       run: |
-        image='${{ steps.buildah-build.outputs.image }}'
+        image='${{ env.IMAGE_NAME }}'
         ids="$(
-          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          for tag in ${{ steps.calculate.outputs.tags }} ; do
             buildah images --quiet --no-trunc "${image}:${tag}"
           done
           )"

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -24,7 +24,7 @@ jobs:
       DEBIAN_VERSION: '10.9'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
@@ -24,7 +24,7 @@ jobs:
       DEBIAN_VERSION: '10.9'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       id: buildah-build

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -1,4 +1,4 @@
-name: 'Build & Push: base-glibc-debian-bash'
+name: 'Build & Push: base-glibc-debian-bash 2'
 on:
   push:
     branches:
@@ -14,19 +14,24 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '2.1.0'
+      IMAGE_VERSION: '3.0.0'
       IMAGE_NAME: base-glibc-debian-bash
-      DEBIAN_VERSION: '10.9'
+      DEBIAN_VERSION: '10.12'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Build
-      id: buildah-build
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+
+    - name: Calculate tags and labels
+      id: calculate
       run: |
         set -xeu
         cd 'images/${{ env.IMAGE_NAME }}'
@@ -44,10 +49,10 @@ jobs:
         debian="$( run cat /etc/debian_version | sed '1!d' )"
         bash="$( run bash --version | sed '1!d' )"
         buildah rm "${container}"
-
-        container="$( buildah from "${image_id}" )"
-        buildah config --label=glibc="${glibc}" "${container}"
-        buildah config --label=debian="${debian}" "${container}"
+        labels="
+          glibc=${glibc}
+          debian=${debian}
+        "
 
         glibc_version="$( printf %s "${glibc}" | sed -E 's/.*version ([0-9.]*[0-9]).*/\1/' )"
         debian_version="$( printf %s "${debian}" | sed -E 's|/|_|g' )"
@@ -57,18 +62,21 @@ jobs:
           ${{ env.IMAGE_VERSION }}_${glibc_version}_${debian_version}_${bash_version}
           latest
         "
+        
+        echo "tags=$( echo ${tags} )" >> $GITHUB_OUTPUT
+        echo "labels=$( echo ${labels} )" >> $GITHUB_OUTPUT
 
-        image_id="$( buildah commit "${container}" )"
-        buildah rm "${container}"
-        image_name='${{ env.IMAGE_NAME }}'
-
-        for tag in ${tags} ; do
-          buildah tag "${image_id}" \
-            "${image_name}":"${tag}"
-        done
-
-        echo "::set-output name=image::${image_name}"
-        echo "::set-output name=tags::$( echo ${tags} )"
+    - name: Build multiarch image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ steps.calculate.outputs.tags }}
+        labels: ${{ steps.calculate.outputs.labels }}
+        archs: amd64,arm64
+        build-args: |
+          debian_version=${{ env.DEBIAN_VERSION }}
+        containerfiles: |
+            ./images/${{ env.IMAGE_NAME }}/Dockerfile
 
     - name: Test
       run: |
@@ -92,9 +100,8 @@ jobs:
       run: |
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
-        response=$(
-          curl -H "Authorization: Bearer $TOKEN" \
-             -sL \
+        respone="$(
+          curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
             'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
           )
 
@@ -121,22 +128,22 @@ jobs:
       env:
         TOKEN: ${{ secrets.secrets.QUAY_BIOCONDA_TOKEN }}
 
-    - if: ${{ github.ref == 'refs/heads/main' }}
-      name: Push
+    - name: Push To quay.io
+      id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ steps.buildah-build.outputs.image }}
-        tags: ${{ steps.buildah-build.outputs.tags }}
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ steps.calculate.outputs.tags }}
         registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
         username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
         password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
-
+      
     - if: ${{ github.ref == 'refs/heads/main' }}
       name: Test Pushed
       run: |
-        image='${{ steps.buildah-build.outputs.image }}'
+        image='${{ env.IMAGE_NAME }}'
         ids="$(
-          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          for tag in ${{ steps.calculate.outputs.tags }} ; do
             buildah images --quiet --no-trunc "${image}:${tag}"
           done
         )"

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -81,9 +81,9 @@ jobs:
 
     - name: Test
       run: |
-        image='${{ steps.buildah-build.outputs.image }}'
+        image='${{ steps.build.outputs.image }}'
         ids="$(
-          for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+          for tag in ${{ steps.calculate.outputs.tags }} ; do
             buildah images --quiet --no-trunc "${image}:${tag}"
           done
           )"

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -99,9 +99,10 @@ jobs:
 
     - name: Check Tags
       run: |
+        set -x
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
-        respone="$(
+        response="$(
           curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
             'https://quay.io/api/v1/repository/bioconda/${{ steps.build.outputs.image }}/image'
           )"
@@ -115,7 +116,7 @@ jobs:
               'Could not get list of image tags.' \
               'Does the repository exist on Quay.io?' \
               'Quay.io REST API response was:' \
-              "${respone}"
+              "${response}"
             exit 1
           }
         for tag in ${{ steps.calculate.outputs.tags }} ; do

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -23,7 +23,7 @@ jobs:
       DEBIAN_VERSION: '10.9'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -1,4 +1,4 @@
-name: 'Build & Push: base-glibc-debian-bash 2'
+name: 'Build & Push: base-glibc-debian-bash'
 on:
   push:
     branches:
@@ -20,7 +20,7 @@ jobs:
       # version tags or checksum IDs, but not via "latest".
       IMAGE_VERSION: '3.0.0'
       IMAGE_NAME: base-glibc-debian-bash
-      DEBIAN_VERSION: '10.12'
+      DEBIAN_VERSION: '10.9'
 
     steps:
     - uses: actions/checkout@v3
@@ -67,6 +67,7 @@ jobs:
         echo "labels=$( echo ${labels} )" >> $GITHUB_OUTPUT
 
     - name: Build multiarch image
+      id: build
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_NAME }}
@@ -102,8 +103,8 @@ jobs:
         #               => Try to use the REST API to check for duplicate tags.
         respone="$(
           curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
-            'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
-          )
+            'https://quay.io/api/v1/repository/bioconda/${{ steps.build.outputs.image }}/image'
+          )"
 
         existing_tags="$(
           printf %s "${response}" \
@@ -117,7 +118,7 @@ jobs:
               "${respone}"
             exit 1
           }
-        for tag in ${{ steps.buildah-build.outputs.tags }} ; do
+        for tag in ${{ steps.calculate.outputs.tags }} ; do
           if [ \! "${tag}" = latest ] ; then
             if printf %s "${existing_tags}" | grep -qxF "${tag}" ; then
               printf 'Tag %s already exists!\n' "${tag}"
@@ -128,20 +129,21 @@ jobs:
       env:
         TOKEN: ${{ secrets.secrets.QUAY_BIOCONDA_TOKEN }}
 
-    - name: Push To quay.io
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Push To quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: ${{ env.IMAGE_NAME }}
+        image: ${{ steps.build.outputs.image }}
         tags: ${{ steps.calculate.outputs.tags }}
         registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
         username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
         password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
-      
+
     - if: ${{ github.ref == 'refs/heads/main' }}
       name: Test Pushed
       run: |
-        image='${{ env.IMAGE_NAME }}'
+        image='${{ steps.build.outputs.image }}'
         ids="$(
           for tag in ${{ steps.calculate.outputs.tags }} ; do
             buildah images --quiet --no-trunc "${image}:${tag}"

--- a/.github/workflows/bioconda-recipes-issue-responder.yaml
+++ b/.github/workflows/bioconda-recipes-issue-responder.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IMAGE_NAME: bioconda-recipes-issue-responder
       IMAGE_VERSION: '1.1.1'

--- a/.github/workflows/bioconda-recipes-issue-responder.yaml
+++ b/.github/workflows/bioconda-recipes-issue-responder.yaml
@@ -20,7 +20,7 @@ jobs:
       IMAGE_VERSION: '1.1.1'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build
       id: buildah-build

--- a/.github/workflows/bioconda-recipes-issue-responder.yaml
+++ b/.github/workflows/bioconda-recipes-issue-responder.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       IMAGE_NAME: bioconda-recipes-issue-responder
       IMAGE_VERSION: '1.1.1'

--- a/.github/workflows/bioconda-recipes-issue-responder.yaml
+++ b/.github/workflows/bioconda-recipes-issue-responder.yaml
@@ -20,7 +20,7 @@ jobs:
       IMAGE_VERSION: '1.1.1'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       id: buildah-build

--- a/.github/workflows/bioconda-recipes-issue-responder.yaml
+++ b/.github/workflows/bioconda-recipes-issue-responder.yaml
@@ -57,7 +57,7 @@ jobs:
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
         respone="$(
-          curl -sL \
+          curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
             'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
           )"
 

--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -29,7 +29,7 @@ jobs:
       IMAGE_VERSION: '1.1.23'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       id: buildah-build

--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -29,7 +29,7 @@ jobs:
       IMAGE_VERSION: '1.1.23'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build
       id: buildah-build

--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -23,7 +23,7 @@ jobs:
           packages: "anaconda-client skopeo"
         - tag: update
           packages: "git openssh"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IMAGE_NAME: bot
       IMAGE_VERSION: '1.1.23'

--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -23,7 +23,7 @@ jobs:
           packages: "anaconda-client skopeo"
         - tag: update
           packages: "git openssh"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       IMAGE_NAME: bot
       IMAGE_VERSION: '1.1.23'

--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -68,7 +68,7 @@ jobs:
     #    # FIX upstream: Quay.io does not support immutable images currently.
     #    #               => Try to use the REST API to check for duplicate tags.
     #    respone="$(
-    #      curl -sL \
+    #      curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
     #        'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
     #      )"
 

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -22,11 +22,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
     - name: Prepare
       id: prepare
       run: |

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build & Push
     runs-on: ubuntu-20.04
     env:
-      IMAGE_VERSION: '2.2.1'
+      IMAGE_VERSION: '3.0.0'
       IMAGE_NAME: create-env
 
     steps:

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -22,6 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+
     - name: Prepare
       id: prepare
       run: |
@@ -38,8 +43,9 @@ jobs:
         tags: >-
           latest
           ${{ env.IMAGE_VERSION }}
+        archs: amd64,arm64
         context: ./images/${{ env.IMAGE_NAME }}
-        dockerfiles: |
+        containerfiles: |
           ./images/${{ env.IMAGE_NAME }}/Dockerfile
         build-args: |
           bioconda_utils_version=${{ steps.prepare.outputs.bioconda_utils_version }}

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -20,7 +20,7 @@ jobs:
       IMAGE_NAME: create-env
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Prepare
       id: prepare

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IMAGE_VERSION: '3.0.0'
       IMAGE_NAME: create-env

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -77,7 +77,7 @@ jobs:
         while [ "${has_additional}" = 'true' ] ; do
           page="$(( page + 1 ))"
           respone="$(
-            curl -sL \
+            curl -sL -H "Authorization: Bearer ${{ secrets.QUAY_BIOCONDA_TOKEN }}" \
               'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/tag?limit=100&page='"${page}"
             )"
           has_additional="$( printf %s "${respone}" | jq -r '.has_additional' )"

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -43,7 +43,7 @@ jobs:
         tags: >-
           latest
           ${{ env.IMAGE_VERSION }}
-        archs: amd64,arm64
+        archs: amd64
         context: ./images/${{ env.IMAGE_NAME }}
         containerfiles: |
           ./images/${{ env.IMAGE_NAME }}/Dockerfile

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -20,7 +20,7 @@ jobs:
       IMAGE_NAME: create-env
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Prepare
       id: prepare

--- a/images/base-glibc-busybox-bash/Dockerfile
+++ b/images/base-glibc-busybox-bash/Dockerfile
@@ -15,6 +15,9 @@ FROM "debian:${debian_version}-slim" AS build_base
 # (or not want) to include.
 # Use old Debian version to ensure compatible (low glibc requirement) binaries.
 FROM debian:9-slim AS busybox_builder
+RUN echo "deb http://archive.debian.org/debian/ stretch main contrib non-free" > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y \
       bzip2 curl ca-certificates tar gcc gnupg dirmngr make

--- a/images/base-glibc-busybox-bash/Dockerfile.test
+++ b/images/base-glibc-busybox-bash/Dockerfile.test
@@ -17,9 +17,11 @@ RUN [ "$( sh -lc 'printf world' )" = 'world' ] \
     printf '' \
       > /usr/local/env-activate.sh
 
-COPY --from=debian:9-slim /lib/x86_64-linux-gnu/libz.so* /lib/x86_64-linux-gnu/
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+COPY --from=debian:9-slim /lib/*-linux-gnu/libz.so* /lib/*-linux-gnu/
+RUN ARCH=$(uname -m) \
     && \
-    sh ./Miniconda3-latest-Linux-x86_64.sh -bp /opt/conda \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh \
+    && \
+    sh ./Miniconda3-latest-Linux-${ARCH}.sh -bp /opt/conda \
     && \
     /opt/conda/bin/conda info --all

--- a/images/base-glibc-busybox-bash/install-pkgs
+++ b/images/base-glibc-busybox-bash/install-pkgs
@@ -1,6 +1,7 @@
 #! /bin/sh
 set -xeu
 
+ARCH=$(uname -m)
 
 prepare_remove_docs() {
   # remove lintian and docs (apart from copyright)
@@ -41,7 +42,7 @@ prepare() {
       # Update gconv-modules accordingly.
       # NOTE: When adding/removing any, check required dyn. linked libs!
 
-      local gconv_path='./usr/lib/x86_64-linux-gnu/gconv'
+      local gconv_path="./usr/lib/${ARCH}-linux-gnu/gconv"
       local gconv_modules_regex='UTF-\w+|UNICODE|ISO8859-(1|2|15)|CP125(0|1|2)|MACINTOSH'
       local gconv_modules_file_tmp='./.tmp.gconv-modules'
 
@@ -65,7 +66,7 @@ prepare() {
     bash )
       rm -rf ./usr/share/locale
       # Add custom rpath for libtinfo (see below) to bash binaries.
-      local new_rpath='/lib/x86_64-linux-gnu/terminfo:/usr/lib/x86_64-linux-gnu/terminfo'
+      local new_rpath="/lib/${ARCH}-linux-gnu/terminfo:/usr/lib/${ARCH}-linux-gnu/terminfo"
       add_rpath ./bin/bash "${new_rpath}"
       add_rpath ./usr/bin/clear_console "${new_rpath}"
       ;;
@@ -73,20 +74,20 @@ prepare() {
     libtinfo6 )
       # Move libtinfo libraries to a custom path to ensure it is not
       # unintentionally used in downstream images.
-      find ./usr/lib/x86_64-linux-gnu -type f \
+      find ./usr/lib/${ARCH}-linux-gnu -type f \
         | {
           while read binary ; do
-            add_rpath "${binary}" '/lib/x86_64-linux-gnu/terminfo'
+            add_rpath "${binary}" "/lib/${ARCH}-linux-gnu/terminfo"
           done
         }
 
-      mv ./lib/x86_64-linux-gnu ./temp
-      mkdir ./lib/x86_64-linux-gnu
-      mv ./temp ./lib/x86_64-linux-gnu/terminfo
+      mv ./lib/${ARCH}-linux-gnu ./temp
+      mkdir ./lib/${ARCH}-linux-gnu
+      mv ./temp ./lib/${ARCH}-linux-gnu/terminfo
 
-      mv ./usr/lib/x86_64-linux-gnu ./temp
-      mkdir ./usr/lib/x86_64-linux-gnu
-      mv ./temp ./usr/lib/x86_64-linux-gnu/terminfo
+      mv ./usr/lib/${ARCH}-linux-gnu ./temp
+      mkdir ./usr/lib/${ARCH}-linux-gnu
+      mv ./temp ./usr/lib/${ARCH}-linux-gnu/terminfo
       ;;
     libc-bin | \
     libgcc1 | \

--- a/images/base-glibc-debian-bash/Dockerfile.test
+++ b/images/base-glibc-debian-bash/Dockerfile.test
@@ -28,8 +28,10 @@ RUN apt-get update -qq \
       ca-certificates \
       wget \
     && \
-    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    ARCH=$(uname -m) \
     && \
-    sh ./Miniconda3-latest-Linux-x86_64.sh -bp /opt/conda \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh \
+    && \
+    sh ./Miniconda3-latest-Linux-${ARCH}.sh -bp /opt/conda \
     && \
     /opt/conda/bin/conda info --all

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -1,4 +1,3 @@
-ARG arch=x86_64
 # Use the exact conda, mamba versions as used in bioconda-recipes' builds.
 ARG bioconda_utils_version='1.1.3'
 FROM quay.io/bioconda/bioconda-utils-build-env-cos7:${bioconda_utils_version} as bioconda-build-env
@@ -14,7 +13,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${arch}.sh ./miniconda.sh
+RUN wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-RUN apt-get install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
+RUN apt-get update && apt-get install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-RUN sudo yum install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
+RUN yum install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -1,3 +1,4 @@
+ARG arch=x86_64
 # Use the exact conda, mamba versions as used in bioconda-recipes' builds.
 ARG bioconda_utils_version='1.1.3'
 FROM quay.io/bioconda/bioconda-utils-build-env-cos7:${bioconda_utils_version} as bioconda-build-env
@@ -13,7 +14,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh ./miniconda.sh
+ADD https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${arch}.sh ./miniconda.sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-RUN yum install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
+RUN apt-get install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-RUN apt-get update && apt-get install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
+RUN apt-get update && apt-get install -y wget && wget -O ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -13,7 +13,7 @@ FROM quay.io/bioconda/base-glibc-debian-bash as build
 WORKDIR /tmp/work
 COPY --from=bioconda-build-env /tmp/requirements.txt ./
 COPY install-conda print-env-activate create-env ./
-RUN wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
+RUN sudo yum install -y wget && wget -o ./miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh
 
 RUN ./install-conda ./requirements.txt /opt/create-env
 


### PR DESCRIPTION
Add support for Linux ARM64 to `base-glibc-busybox-bash` and `base-glibc-debian-bash` images.

Update the Github runners to 20.04 because the 18.04 ones never start (they stay in `Queued` state for days). See https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Fix warnings:
- update actions/checkout to v4, so that it does not use the deprecated Nodejs v12
- use `>> $GITHUB_OUTPUT` instead of the deprecated `set-output`

Multi-arch images built by my fork could be seen here:
- https://github.com/martin-g/bioconda-containers/pkgs/container/base-glibc-busybox-bash
- https://github.com/martin-g/bioconda-containers/pkgs/container/base-glibc-debian-bash