### PR TITLE
Extend debian base image with libegl1 and libopengl0

### DIFF
--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -14,11 +14,11 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
-      IMAGE_VERSION: '2.1.0'
+      IMAGE_VERSION: '2.1.1'
       IMAGE_NAME: base-glibc-debian-bash
       DEBIAN_VERSION: '10.9'
 

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update -qq \
     apt-get install --yes \
       --no-install-recommends \
       libgl1-mesa-glx \
+      libegl1 \
+      libopengl0 \
       locales \
       openssh-client \
       procps \


### PR DESCRIPTION
This is required to run the bandage biocontainer. Without this bandage fails with `Bandage: error while loading shared libraries: libEGL.so.1: cannot open shared object file: No such file or directory` and `Bandage: error while loading shared libraries: libOpenGL.so.0: cannot open shared object file: No such file or directory` ... I think this was the recommended approach for libraries usually provided by the host OS, but let me know if there's a way to fix this in the recipe instead.