### PR TITLE
Add required token for tag check

### DIFF
--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -92,13 +92,14 @@ jobs:
       run: |
         # FIX upstream: Quay.io does not support immutable images currently.
         #               => Try to use the REST API to check for duplicate tags.
-        respone="$(
-          curl -sL \
+        response=$(
+          curl -H "Authorization: Bearer $TOKEN" \
+             -sL \
             'https://quay.io/api/v1/repository/bioconda/${{ steps.buildah-build.outputs.image }}/image'
-          )"
+          )
 
         existing_tags="$(
-          printf %s "${respone}" \
+          printf %s "${response}" \
             | jq -r '.images[].tags[]'
           )" \
           || {
@@ -117,6 +118,8 @@ jobs:
             fi
           fi
         done
+      env:
+        TOKEN: ${{ secrets.secrets.QUAY_BIOCONDA_TOKEN }}
 
     - if: ${{ github.ref == 'refs/heads/main' }}
       name: Push


### PR DESCRIPTION
The outer quote for the subshell isn't needed.