### PR TITLE
Fix bioconda/base-glibc-busybox-bash:3.0

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -63,7 +63,7 @@ jobs:
 
         for arch in amd64 arm64 ; do
           iidfile="$( mktemp )"
-          buildah bud --layers \
+          buildah bud \
             --arch="${arch}" \
             --iidfile="${iidfile}" \
             --build-arg=busybox_image="${busybox_image}" \

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -135,7 +135,7 @@ jobs:
 
         existing_tags="$(
           printf %s "${response}" \
-            | jq -r '.tags[]|.name'
+            | jq -r '.tags[]|select(.end_ts == null or .end_ts >= now)|.name'
           )" \
           || {
             printf %s\\n \

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -125,7 +125,7 @@ jobs:
 
         existing_tags="$(
           printf %s "${response}" \
-            | jq -r '.tags[]|.name'
+            | jq -r '.tags[]|select(.end_ts == null or .end_ts >= now)|.name'
           )" \
           || {
             printf %s\\n \

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -54,7 +54,7 @@ jobs:
 
         for arch in amd64 arm64 ; do
           iidfile="$( mktemp )"
-          buildah bud --layers \
+          buildah bud \
             --arch="${arch}" \
             --iidfile="${iidfile}" \
             --build-arg=debian_version='${{ env.DEBIAN_VERSION }}'


### PR DESCRIPTION
Remove buildah bud --layers option

The BusyBox base image did not hardlink the BusyBox binaries which bloated it up to around 300 MiB uncompressed. Maybe this fixed it?