### PR TITLE
ci: Use environment variables to set the major and minor versions

### DIFF
--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -119,8 +119,17 @@ jobs:
           password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
 
       - name: Push Docker manifest list for quay.io/bioconda
-        uses: Noelware/docker-manifest-action@v0.3.0
-        with:
-            inputs: quay.io/${{ vars.QUAY_BIOCONDA_USERNAME }}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
-            images: ${{ steps.interpolate.outputs.DOCKER_IMAGES }}
-            push: true
+        run: |
+          PREFIX=${{ secrets.QUAY_BIOCONDA_REPO }}/${{ vars.QUAY_BIOCONDA_USERNAME }}
+          docker manifest create ${PREFIX}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }} \
+            --amend ${PREFIX}/bioconda-utils-build-env-cos7-x86_64:${{ matrix.tag }} \
+            --amend ${PREFIX}/bioconda-utils-build-env-cos7-aarch64:${{ matrix.tag }}
+          
+          docker manifest inspect ${PREFIX}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
+          
+          docker manifest push ${PREFIX}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
+        # uses: Noelware/docker-manifest-action@v0.3.0
+        # with:
+        #     inputs: quay.io/${{ vars.QUAY_BIOCONDA_USERNAME }}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
+        #     images: ${{ steps.interpolate.outputs.DOCKER_IMAGES }}
+        #     push: true

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -11,11 +11,19 @@ on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'images/build-env/**'
+      - '.github/workflows/build-env-image.yml'
+
 
 jobs:
   build:
     name: Build image - ${{ matrix.image }}
     runs-on: ubuntu-22.04
+    env:
+      MAJOR_VERSION: 3
+      MINOR_VERSION: 0
+
     strategy:
       matrix:
         include:
@@ -37,11 +45,6 @@ jobs:
         repository: 'bioconda/bioconda-utils'
         path: 'bioconda-utils'
 
-    - id: get-tag
-      run: |
-        tag=${{ github.event.release && github.event.release.tag_name || github.sha }}
-        printf %s "tag=${tag#v}" >> $GITHUB_OUTPUT
-
     - name: Install qemu dependency
       if: ${{ matrix.arch == 'arm64' }}
       uses: docker/setup-qemu-action@v3
@@ -58,7 +61,8 @@ jobs:
           BASE_IMAGE=${{ matrix.base_image }}
         tags: >-
           latest
-          ${{ steps.get-tag.outputs.tag }}
+          ${{ env.MAJOR_VERSION }}
+          ${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
         dockerfiles: |
           ./images/build-env/Dockerfile
 

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -70,13 +70,11 @@ jobs:
     - name: Test built image
       id: test
       run: |
-        jq --version
-        echo "${{ steps.buildah-build.outputs.tags }}"
         image='${{ steps.buildah-build.outputs.image }}'
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           podman run --rm "${image}:${tag}" bioconda-utils --version
         done
-        tags_json=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${{ steps.buildah-build.outputs.tags }}")
+        tags_json=$(echo -n "${{ steps.buildah-build.outputs.tags }}" | jq --compact-output --raw-input --slurp 'split(" ")')
         echo $tags_json
         echo "tags=${tags_json}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -70,13 +70,14 @@ jobs:
     - name: Test built image
       id: test
       run: |
+        echo "${{ steps.buildah-build.outputs.tags }}"
         image='${{ steps.buildah-build.outputs.image }}'
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           podman run --rm "${image}:${tag}" bioconda-utils --version
         done
         tags_json=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${{ steps.buildah-build.outputs.tags }}")
         echo $tags_json
-        echo "tags=${tags_json}" >> $GITHUB_OUTPUT
+        echo "tags='${tags_json}'" >> $GITHUB_OUTPUT
 
     - name: Push To Quay
       if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            image: bioconda/bioconda-utils-build-env-cos7-aarch64
+            image: ${{ vars.QUAY_BIOCONDA_USERNAME }}/bioconda-utils-build-env-cos7-aarch64
             base_image: quay.io/condaforge/linux-anvil-aarch64
           - arch: amd64
-            image: bioconda/bioconda-utils-build-env-cos7-x86_64
+            image: ${{ vars.QUAY_BIOCONDA_USERNAME }}/bioconda-utils-build-env-cos7-x86_64
             base_image: quay.io/condaforge/linux-anvil-cos7-x86_64
     steps:
     - name: Checkout bioconda-containers
@@ -81,7 +81,7 @@ jobs:
         image: ${{ steps.buildah-build.outputs.image }}
         tags: ${{ steps.buildah-build.outputs.tags }}
         registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
-        username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
+        username: ${{ vars.QUAY_BIOCONDA_USERNAME }}
         password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
 
   build-manifest:
@@ -104,19 +104,19 @@ jobs:
         id: interpolate
         run: |
           set -x
-          INTERPOLATED=`echo "${{ env.DOCKER_IMAGES }}" | sed "s#<<USER>>#${{ secrets.QUAY_BIOCONDA_USERNAME }}#g" | sed "s#<<TAG>>#${{ matrix.tag }}#g"`
+          INTERPOLATED=`echo "${{ env.DOCKER_IMAGES }}" | sed "s#<<USER>>#${{ vars.QUAY_BIOCONDA_USERNAME }}#g" | sed "s#<<TAG>>#${{ matrix.tag }}#g"`
           echo "DOCKER_IMAGES=${INTERPOLATED}" >> "$GITHUB_OUTPUT"
 
       - name: Login to Quay.io registry
         uses: docker/login-action@v2
         with:
           registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
-          username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
+          username: ${{ vars.QUAY_BIOCONDA_USERNAME }}
           password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
 
       - name: Push Docker manifest list for quay.io/bioconda
         uses: Noelware/docker-manifest-action@v0.3.0
         with:
-            inputs: quay.io/${{ secrets.QUAY_BIOCONDA_USERNAME }}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
+            inputs: quay.io/${{ vars.QUAY_BIOCONDA_USERNAME }}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
             images: ${{ steps.interpolate.outputs.DOCKER_IMAGES }}
             push: true

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -70,6 +70,7 @@ jobs:
     - name: Test built image
       id: test
       run: |
+        jq --version
         echo "${{ steps.buildah-build.outputs.tags }}"
         image='${{ steps.buildah-build.outputs.image }}'
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
@@ -77,7 +78,7 @@ jobs:
         done
         tags_json=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${{ steps.buildah-build.outputs.tags }}")
         echo $tags_json
-        echo "tags='${tags_json}'" >> $GITHUB_OUTPUT
+        echo "tags=${tags_json}" >> $GITHUB_OUTPUT
 
     - name: Push To Quay
       if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -23,6 +23,8 @@ jobs:
   build:
     name: Build image - ${{ matrix.image }}
     runs-on: ubuntu-22.04
+    outputs:
+      tags: ${{ steps.buildah-build.outputs.tags }}
     strategy:
       matrix:
         include:
@@ -85,15 +87,15 @@ jobs:
   build-manifest:
     needs: [build]
     if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
-    name: quay.io/bioconda/${{ matrix.cfg.DOCKER_MANIFEST }}:${{ matrix.cfg.DOCKER_TAG }}
-    runs-on: ubuntu-latest
+    name: Build and push Docker manifest
+    runs-on: ubuntu-22.04
+    env:
+      DOCKER_MANIFEST: bioconda-utils-build-env-cos7
+      DOCKER_IMAGES: "quay.io/<<USER>>/bioconda-utils-build-env-cos7:<<TAG>>,quay.io/<<USER>>/bioconda-utils-build-env-cos7-aarch64:<<TAG>>"
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        cfg:
-          - DOCKER_MANIFEST: bioconda-utils-build-env-cos7
-            DOCKER_TAG: "latest"
-            DOCKER_IMAGES: "quay.io/<<USER>>/bioconda-utils-build-env-cos7:<<TAG>>,quay.io/<<USER>>/bioconda-utils-build-env-cos7-aarch64:<<TAG>>"
+        tag: ${{ fromJson(needs.build.outputs.tags) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +104,7 @@ jobs:
         id: interpolate
         run: |
           set -x
-          INTERPOLATED=`echo "${{ matrix.cfg.DOCKER_IMAGES }}" | sed "s#<<USER>>#${{ secrets.QUAY_BIOCONDA_USERNAME }}#g" | sed "s#<<TAG>>#${{ matrix.cfg.DOCKER_TAG }}#g"`
+          INTERPOLATED=`echo "${{ env.DOCKER_IMAGES }}" | sed "s#<<USER>>#${{ secrets.QUAY_BIOCONDA_USERNAME }}#g" | sed "s#<<TAG>>#${{ matrix.tag }}#g"`
           echo "DOCKER_IMAGES=${INTERPOLATED}" >> "$GITHUB_OUTPUT"
 
       - name: Login to Quay.io registry
@@ -115,6 +117,6 @@ jobs:
       - name: Push Docker manifest list for quay.io/bioconda
         uses: Noelware/docker-manifest-action@v0.3.0
         with:
-            inputs: quay.io/${{ secrets.QUAY_BIOCONDA_USERNAME }}/${{ matrix.cfg.DOCKER_MANIFEST }}:${{ matrix.cfg.DOCKER_TAG }}
+            inputs: quay.io/${{ secrets.QUAY_BIOCONDA_USERNAME }}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
             images: ${{ steps.interpolate.outputs.DOCKER_IMAGES }}
             push: true

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -75,7 +75,7 @@ jobs:
         done
 
     - name: Push To Quay
-      if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
+      # if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.buildah-build.outputs.image }}
@@ -86,7 +86,7 @@ jobs:
 
   build-manifest:
     needs: [build]
-    if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
+    # if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
     name: Build and push Docker manifest
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            image: ${{ vars.QUAY_BIOCONDA_USERNAME }}/bioconda-utils-build-env-cos7-aarch64
+            image: bioconda/bioconda-utils-build-env-cos7-aarch64
             base_image: quay.io/condaforge/linux-anvil-aarch64
           - arch: amd64
-            image: ${{ vars.QUAY_BIOCONDA_USERNAME }}/bioconda-utils-build-env-cos7-x86_64
+            image: bioconda/bioconda-utils-build-env-cos7-x86_64
             base_image: quay.io/condaforge/linux-anvil-cos7-x86_64
     steps:
     - name: Checkout bioconda-containers
@@ -75,7 +75,6 @@ jobs:
           podman run --rm "${image}:${tag}" bioconda-utils --version
         done
         tags_json=$(echo -n "${{ steps.buildah-build.outputs.tags }}" | jq --compact-output --raw-input --slurp 'split(" ")')
-        echo $tags_json
         echo "tags=${tags_json}" >> $GITHUB_OUTPUT
 
     - name: Push To Quay
@@ -85,7 +84,7 @@ jobs:
         image: ${{ steps.buildah-build.outputs.image }}
         tags: ${{ steps.buildah-build.outputs.tags }}
         registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
-        username: ${{ vars.QUAY_BIOCONDA_USERNAME }}
+        username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
         password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
 
   build-manifest:
@@ -108,19 +107,19 @@ jobs:
         id: interpolate
         run: |
           set -x
-          INTERPOLATED=`echo "${{ env.DOCKER_IMAGES }}" | sed "s#<<USER>>#${{ vars.QUAY_BIOCONDA_USERNAME }}#g" | sed "s#<<TAG>>#${{ matrix.tag }}#g"`
+          INTERPOLATED=`echo "${{ env.DOCKER_IMAGES }}" | sed "s#<<USER>>#${{ secrets.QUAY_BIOCONDA_USERNAME }}#g" | sed "s#<<TAG>>#${{ matrix.tag }}#g"`
           echo "DOCKER_IMAGES=${INTERPOLATED}" >> "$GITHUB_OUTPUT"
 
       - name: Login to Quay.io registry
         uses: docker/login-action@v2
         with:
           registry: ${{ secrets.QUAY_BIOCONDA_REPO }}
-          username: ${{ vars.QUAY_BIOCONDA_USERNAME }}
+          username: ${{ secrets.QUAY_BIOCONDA_USERNAME }}
           password: ${{ secrets.QUAY_BIOCONDA_TOKEN }}
 
       - name: Push Docker manifest list for quay.io/bioconda
         run: |
-          PREFIX=${{ secrets.QUAY_BIOCONDA_REPO }}/${{ vars.QUAY_BIOCONDA_USERNAME }}
+          PREFIX=${{ secrets.QUAY_BIOCONDA_REPO }}/${{ secrets.QUAY_BIOCONDA_USERNAME }}
           docker manifest create ${PREFIX}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }} \
             --amend ${PREFIX}/bioconda-utils-build-env-cos7-x86_64:${{ matrix.tag }} \
             --amend ${PREFIX}/bioconda-utils-build-env-cos7-aarch64:${{ matrix.tag }}
@@ -128,8 +127,3 @@ jobs:
           docker manifest inspect ${PREFIX}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
           
           docker manifest push ${PREFIX}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
-        # uses: Noelware/docker-manifest-action@v0.3.0
-        # with:
-        #     inputs: quay.io/${{ vars.QUAY_BIOCONDA_USERNAME }}/${{ env.DOCKER_MANIFEST }}:${{ matrix.tag }}
-        #     images: ${{ steps.interpolate.outputs.DOCKER_IMAGES }}
-        #     push: true

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -15,15 +15,14 @@ on:
       - 'images/build-env/**'
       - '.github/workflows/build-env-image.yml'
 
-
+env:
+  MAJOR_VERSION: 3
+  MINOR_VERSION: 0
+  
 jobs:
   build:
     name: Build image - ${{ matrix.image }}
     runs-on: ubuntu-22.04
-    env:
-      MAJOR_VERSION: 3
-      MINOR_VERSION: 0
-
     strategy:
       matrix:
         include:
@@ -45,11 +44,11 @@ jobs:
         repository: 'bioconda/bioconda-utils'
         path: 'bioconda-utils'
 
-    - name: Install qemu dependency
-      if: ${{ matrix.arch == 'arm64' }}
+    - name: Install QEMU dependency
+      if: ${{ matrix.arch != 'amd64' }}
       uses: docker/setup-qemu-action@v3
       with:
-        platforms: arm64
+        platforms: ${{ matrix.arch }}
 
     - name: Build image
       id: buildah-build

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -89,7 +89,7 @@ jobs:
 
   build-manifest:
     needs: [build]
-    # if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
+    if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
     name: Build and push Docker manifest
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/build-env-image.yml
+++ b/.github/workflows/build-env-image.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build image - ${{ matrix.image }}
     runs-on: ubuntu-22.04
     outputs:
-      tags: ${{ steps.buildah-build.outputs.tags }}
+      tags: ${{ steps.test.outputs.tags }}
     strategy:
       matrix:
         include:
@@ -68,14 +68,18 @@ jobs:
           ./images/build-env/Dockerfile
 
     - name: Test built image
+      id: test
       run: |
         image='${{ steps.buildah-build.outputs.image }}'
         for tag in ${{ steps.buildah-build.outputs.tags }} ; do
           podman run --rm "${image}:${tag}" bioconda-utils --version
         done
+        tags_json=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${{ steps.buildah-build.outputs.tags }}")
+        echo $tags_json
+        echo "tags=${tags_json}" >> $GITHUB_OUTPUT
 
     - name: Push To Quay
-      # if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
+      if: github.ref == 'refs/heads/main' && github.repository == 'bioconda/bioconda-containers'
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.buildah-build.outputs.image }}


### PR DESCRIPTION
Use same versions as in the other Docker images:
- major -> 3
- minor -> 0

Use `docker manifest` cli to create and push the manifest.
Improve the step that installs QEMU to be better prepared for adding support for more CPU architectures.

Suggested-at: https://github.com/bioconda/bioconda-containers/pull/68#issuecomment-1893793704