### PR TITLE
re-add circleci artifact fetching

### DIFF
--- a/images/bot/setup.cfg
+++ b/images/bot/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bioconda-bot
-version = 0.0.1
+version = 0.0.2
 
 [options]
 python_requires = >=3.8

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -26,10 +26,10 @@ log = logger.info
 async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> None:
     artifacts = await fetch_pr_sha_artifacts(session, pr, sha)
     
-    comment = compose_azure_comment(artifacts["azure"])
+    comment = compose_azure_comment(artifacts["azure"] if "azure" in artifacts else [])
     if len(comment) > 0:
         comment += "\n\n"
-    comment += compose_circlci_comment(artifacts["circleci"])
+    comment += compose_circlci_comment(artifacts["circleci"] if "circleci" in artifacts else [])
 
     await send_comment(session, pr, comment)
 
@@ -88,7 +88,7 @@ def compose_azure_comment(artifacts: List[Tuple[str, str]]) -> str:
     else:
         comment += (
             "No artifacts found on the most recent Azure build. "
-            "Either the build failed, the artifacts have were removed due to age, or the recipe was blacklisted/skipped."
+            "Either the build failed, the artifacts have been removed due to age, or the recipe was blacklisted/skipped."
         )
     return comment
 

--- a/images/bot/src/bioconda_bot/common.py
+++ b/images/bot/src/bioconda_bot/common.py
@@ -137,9 +137,40 @@ async def fetch_azure_zip_files(session: ClientSession, buildId: str) -> [(str, 
 def parse_azure_build_id(url: str) -> str:
     return re.search("buildId=(\d+)", url).group(1)
 
+# Find artifact zip files, download them and return their URLs and contents
+async def fetch_circleci_artifacts(session: ClientSession, workflowId: str) -> [(str, str)]:
+    artifacts = []
+
+    url_wf = f"https://circleci.com/api/v2/workflow/{workflowId}/job"
+    async with session.get(url_wf) as response:
+        # Sometimes we get a 301 error, so there are no longer artifacts available
+        if response.status == 301:
+            return artifacts
+        res_wf = await response.text()
+
+    res_wf_object = safe_load(res_wf)
+
+    if len(res_wf_object["items"]) == 0:
+        return artifacts
+    else:
+        for job in res_wf_object["items"]:
+            if job["name"].startswith(f"build_and_test-"):
+                circleci_job_num = job["job_number"]
+                url = f"https://circleci.com/api/v2/project/gh/bioconda/bioconda-recipes/{circleci_job_num}/artifacts"
+
+                async with session.get(url) as response:
+                    res = await response.text()
+
+                res_object = safe_load(res)
+                for artifact in res_object["items"]:
+                    zipUrl = artifact["url"]
+                    pkg = artifact["path"]
+                    if zipUrl.endswith(".tar.bz2"): # (currently excluding container images) or zipUrl.endswith(".tar.gz"):
+                        artifacts.append((zipUrl, pkg))
+        return artifacts
 
 # Given a PR and commit sha, fetch a list of the artifact zip files URLs and their contents
-async def fetch_pr_sha_artifacts(session: ClientSession, pr: int, sha: str) -> List[Tuple[str, str]]:
+async def fetch_pr_sha_artifacts(session: ClientSession, pr: int, sha: str) -> Dict[str, List[Tuple[str, str]]]:
     url = f"https://api.github.com/repos/bioconda/bioconda-recipes/commits/{sha}/check-runs"
 
     headers = {
@@ -151,15 +182,28 @@ async def fetch_pr_sha_artifacts(session: ClientSession, pr: int, sha: str) -> L
         res = await response.text()
     check_runs = safe_load(res)
 
+    artifact_sources = {}
     for check_run in check_runs["check_runs"]:
-        # The names are "bioconda.bioconda-recipes (test_osx test_osx)" or similar
-        if check_run["name"].startswith("bioconda.bioconda-recipes (test_"):
+        if (
+            "azure" not in artifact_sources and 
+            check_run["app"]["slug"] == "azure-pipelines" and
+            check_run["name"].startswith("bioconda.bioconda-recipes (test_")
+        ):
+            # azure builds
             # The azure build ID is in the details_url as buildId=\d+
             buildID = parse_azure_build_id(check_run["details_url"])
             zipFiles = await fetch_azure_zip_files(session, buildID)
-            return zipFiles  # We've already fetched all possible artifacts
+            artifact_sources["azure"] = zipFiles  # We've already fetched all possible artifacts from Azure
+        elif (
+            "circleci" not in artifact_sources and 
+            check_run["app"]["slug"] == "circleci-checks"
+        ):
+            # Circle CI builds
+            workflowId = safe_load(check_run["external_id"])["workflow-id"]
+            zipFiles = await fetch_circleci_artifacts(session, workflowId)
+            artifact_sources["circleci"] = zipFiles  # We've already fetched all possible artifacts from CircleCI
 
-    return []
+    return artifact_sources
 
 
 async def get_sha_for_status(job_context: Dict[str, Any]) -> Optional[str]:

--- a/images/bot/src/bioconda_bot/merge.py
+++ b/images/bot/src/bioconda_bot/merge.py
@@ -271,7 +271,9 @@ async def upload_artifacts(session: ClientSession, pr: int) -> str:
     sha: str = pr_info["head"]["sha"]
 
     # Fetch the artifacts (a list of (URL, artifact) tuples actually)
-    artifacts = await fetch_pr_sha_artifacts(session, pr, sha)
+    artifactDict = await fetch_pr_sha_artifacts(session, pr, sha)
+    # Merge is deprecated, so leaving as Azure only
+    artifacts = artifactDict["azure"]
     artifacts = [artifact for (URL, artifact) in artifacts if artifact.endswith((".gz", ".bz2"))]
     assert artifacts
 


### PR DESCRIPTION
Re-added CircleCI artifact fetching for linux-aarch64 builds. 

- This will not include the docker images built by CircleCI, but the code is there only [one line](https://github.com/bioconda/bioconda-containers/blob/14075c83c1c36d1f4d680c506df64532b62daab5/images/bot/src/bioconda_bot/common.py#L168) needs to be modified to include `*.tar.gz`. 
- I kept the comment format for CircleCI that was in the previous version because the artifacts are downloadable individually, not as a zip.
- If there are no CircleCI artifacts, that section will not be included at all. (If there are no Azure artifacts, there is a message suggesting possible problems.)
- I saw [here](https://github.com/bioconda/bioconda-recipes/blob/261c54e71b484810d46e9f9e80071e8f196a3a82/.github/workflows/CommentResponder.yml#L90) that the `merge` functionality is disabled, so I did not do anything to support CircleCI there.



Sample comment for PR https://github.com/bioconda/bioconda-recipes/pull/46173 
***
## Azure

Package(s) built on Azure are ready for inspection:

Arch | Package | Zip File
-----|---------|---------
linux-64 | spacepharer-5.c2e680a-pl5321h6a68c12_4.tar.bz2 | [LinuxArtifacts](https://artprodsu6weu.artifacts.visualstudio.com/A27bcc0f9-b22c-4418-83d8-514809b37fb2/25074ded-3133-43ca-af80-895ab87b53cb/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2Jpb2NvbmRhL3Byb2plY3RJZC8yNTA3NGRlZC0zMTMzLTQzY2EtYWY4MC04OTVhYjg3YjUzY2IvYnVpbGRJZC81MjQyMi9hcnRpZmFjdE5hbWUvTGludXhBcnRpZmFjdHM1/content?format=zip)
osx-64 | spacepharer-5.c2e680a-pl5321hf590d3d_4.tar.bz2 | [OSXArtifacts](https://artprodsu6weu.artifacts.visualstudio.com/A27bcc0f9-b22c-4418-83d8-514809b37fb2/25074ded-3133-43ca-af80-895ab87b53cb/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2Jpb2NvbmRhL3Byb2plY3RJZC8yNTA3NGRlZC0zMTMzLTQzY2EtYWY4MC04OTVhYjg3YjUzY2IvYnVpbGRJZC81MjQyMi9hcnRpZmFjdE5hbWUvT1NYQXJ0aWZhY3Rz0/content?format=zip)
***

You may also use `conda` to install these after downloading and extracting the appropriate zip file. From the LinuxArtifacts or OSXArtifacts directories:

```
conda install -c ./packages <package name>
```
***

Docker image(s) built (images for Azure are in the LinuxArtifacts zip file above):

Package | Tag | Install with `docker`
--------|-----|----------------------
spacepharer | 5.c2e680a--pl5321h6a68c12_4 | <details><summary>show</summary>`gzip -dc LinuxArtifacts/images/spacepharer:5.c2e680a--pl5321h6a68c12_4.tar.gz \| docker load`




## CircleCI

Package(s) built on CircleCI are ready for inspection:

Arch | Package | Repodata
-----|---------|---------
linux-aarch64 | [spacepharer-5.c2e680a-pl5321h76f4f2e_4.tar.bz2](https://output.circle-artifacts.com/output/job/32f2bc5a-2105-432e-a955-569c1f5ed4e6/artifacts/0/tmp/artifacts/packages/linux-aarch64/spacepharer-5.c2e680a-pl5321h76f4f2e_4.tar.bz2) | [repodata.json](https://output.circle-artifacts.com/output/job/32f2bc5a-2105-432e-a955-569c1f5ed4e6/artifacts/0/tmp/artifacts/packages/linux-aarch64/repodata.json)
***

You may also use `conda` to install these:

```
conda install -c https://output.circle-artifacts.com/output/job/32f2bc5a-2105-432e-a955-569c1f5ed4e6/artifacts/0/tmp/artifacts/packages <package name>
```
</details>


