### PR TITLE
Replace /bin/sh with a wrapper to /bin/bash

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -19,7 +19,7 @@ jobs:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
       MAJOR_VERSION: 3
-      MINOR_VERSION: 0
+      MINOR_VERSION: 1
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.36.1'
       DEBIAN_VERSION: '12.2'

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -19,7 +19,7 @@ jobs:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
       MAJOR_VERSION: 3
-      MINOR_VERSION: 0
+      MINOR_VERSION: 1
       IMAGE_NAME: base-glibc-debian-bash
       DEBIAN_VERSION: '12.2'
 

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       MAJOR_VERSION: 3
-      MINOR_VERSION: 0
+      MINOR_VERSION: 1
       IMAGE_NAME: create-env
 
     steps:

--- a/images/base-glibc-busybox-bash/Dockerfile.busybox
+++ b/images/base-glibc-busybox-bash/Dockerfile.busybox
@@ -17,6 +17,15 @@ RUN [ ! -f /etc/apt/sources.list ] || sed --in-place= --regexp-extended \
 WORKDIR /build
 COPY build-busybox ./
 ARG busybox_version
+
+RUN echo "umask 022" >> /etc/profile
+RUN echo "umask 022" >> /root/.bashrc
+
+# replace /bin/sh with a wrapper to /bin/bash
+RUN /bin/bash -c "unlink /bin/sh"
+COPY bin-sh-wrapper.sh /bin/sh
+RUN /bin/bash -c "chmod +x /bin/sh"
+
 RUN ./build-busybox \
     "${busybox_version}" \
     x86_64 aarch64

--- a/images/base-glibc-busybox-bash/Dockerfile.test
+++ b/images/base-glibc-busybox-bash/Dockerfile.test
@@ -17,6 +17,9 @@ RUN [ "$( sh -lc 'printf world' )" = 'world' ] \
     printf '' \
       > /usr/local/env-activate.sh
 
+# Check that the umask allows others to read+execute someoneelse's folders
+RUN [ "$( umask )" = '0022' ]
+
 RUN arch=$(uname -m) \
     && \
     wget --quiet \

--- a/images/base-glibc-busybox-bash/bin-sh-wrapper.sh
+++ b/images/base-glibc-busybox-bash/bin-sh-wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+BASH_ENV=/etc/profile bash "$@"

--- a/images/base-glibc-debian-bash/Dockerfile
+++ b/images/base-glibc-debian-bash/Dockerfile
@@ -127,5 +127,14 @@ RUN touch /usr/local/env-activate.sh \
       > /usr/local/env-execute
 
 ENV LANG=C.UTF-8
+
+RUN echo "umask 022" >> /etc/profile
+RUN echo "umask 022" >> /root/.bashrc
+
+# replace /bin/sh with a wrapper to /bin/bash
+RUN /bin/bash -c "unlink /bin/sh"
+COPY bin-sh-wrapper.sh /bin/sh
+RUN /bin/bash -c "chmod +x /bin/sh"
+
 ENTRYPOINT [ "/usr/local/env-execute" ]
 CMD [ "bash" ]

--- a/images/base-glibc-debian-bash/Dockerfile.test
+++ b/images/base-glibc-debian-bash/Dockerfile.test
@@ -17,6 +17,9 @@ RUN [ "$( sh -lc 'printf world' )" = 'world' ] \
     printf '' \
       > /usr/local/env-activate.sh
 
+# Check that the umask allows others to read+execute someoneelse's folders
+RUN [ "$( umask )" = '0022' ]
+
 # Check if all desired locales are there.
 RUN locale -a | grep -i 'c\.utf-\?8' \
     && \

--- a/images/base-glibc-debian-bash/bin-sh-wrapper.sh
+++ b/images/base-glibc-debian-bash/bin-sh-wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bash "$@"

--- a/images/create-env/Dockerfile
+++ b/images/create-env/Dockerfile
@@ -40,5 +40,13 @@ RUN \
       >>   /etc/skel/.bashrc
 ENV ENV=/etc/profile.d/conda.sh
 
+RUN echo "umask 022" >> /etc/profile
+RUN echo "umask 022" >> /root/.bashrc
+
+# replace /bin/sh with a wrapper to /bin/bash
+RUN /bin/bash -c "unlink /bin/sh"
+COPY bin-sh-wrapper.sh /bin/sh
+RUN /bin/bash -c "chmod +x /bin/sh"
+
 ENTRYPOINT [ "/opt/create-env/bin/tini", "--", "/opt/create-env/env-execute" ]
 CMD [ "bash" ]

--- a/images/create-env/Dockerfile.test
+++ b/images/create-env/Dockerfile.test
@@ -29,6 +29,8 @@ RUN set -x && \
       >&2 printf 'found static libraries\n' ; exit 1 \
     ; fi
 
+# Check that the umask allows others to read+execute someoneelse's folders
+RUN [ "$( umask )" = '0022' ]
 
 FROM "${base}" as build_bioconda_package
 RUN set -x && \

--- a/images/create-env/bin-sh-wrapper.sh
+++ b/images/create-env/bin-sh-wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+BASH_ENV=/etc/profile bash "$@"


### PR DESCRIPTION
This is needed to be able to set umask=022 for the Linux aarch64 images that use umask=027 by default.

/bin/sh does not load /etc/profile nor any other rcfile.

See https://github.com/bioconda/bioconda-recipes/pull/46177 for full details and https://github.com/galaxyproject/galaxy/issues/17631 for a summary.