### PR TITLE
feat: download github artifacts and condense comment

### DIFF
--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       IMAGE_NAME: bot
-      IMAGE_VERSION: '1.2.0'
+      IMAGE_VERSION: '1.3.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/images/bot/setup.cfg
+++ b/images/bot/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bioconda-bot
-version = 0.0.3
+version = 0.0.4
 
 [options]
 python_requires = >=3.8

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -24,72 +24,65 @@ log = logger.info
 
 # Given a PR and commit sha, post a comment with any artifacts
 async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> None:
-    artifacts = await fetch_pr_sha_artifacts(session, pr, sha)
+    artifactDict = await fetch_pr_sha_artifacts(session, pr, sha)
     
-    comment = compose_azure_comment(artifacts["azure"] if "azure" in artifacts else [])
-    if len(comment) > 0:
-        comment += "\n\n"
-    comment += compose_circlci_comment(artifacts["circleci"] if "circleci" in artifacts else [])
+    comment = "Package(s) built are ready for inspection:\n\n"
+    comment += "Arch | Package | Zip File / Repodata | CI | Instructions\n"
+    comment += "-----|---------|---------|-----|---------\n"
 
-    await send_comment(session, pr, comment)
+    # Table of packages and zips
+    for [ci_platform, artifacts] in artifactDict.items():
+        if ci_platform == "azure":
+            comment += compose_azure_comment(artifacts)
+        elif ci_platform == "circleci":
+            comment += compose_circlci_comment(artifacts)
+        elif ci_platform == "github-actions":
+            comment += compose_gha_comment(artifacts)
 
-def compose_azure_comment(artifacts: List[Tuple[str, str]]) -> str:
-    nPackages = len(artifacts)
-    comment = "## Azure\n\n"
+    # Table of containers
+    imageHeader = "***\n\nDocker image(s) built:\n\n"
+    imageHeader += "Package | Tag | CI | Install with `docker`\n"
+    imageHeader += "---------|---------|-----|---------\n"
 
-    if nPackages > 0:
-        comment += "Package(s) built on Azure are ready for inspection:\n\n"
-        comment += "Arch | Package | Zip File\n-----|---------|---------\n"
-
-        # Table of packages and zips
-        for URL, artifact in artifacts:
-            if not (package_match := re.match(r"^((.+)\/(.+)\/(.+)\/(.+\.conda|.+\.tar\.bz2))$", artifact)):
-                continue
-            url, archdir, basedir, subdir, packageName = package_match.groups()
-            urlBase = URL[:-3]  # trim off zip from format=
-            urlBase += "file&subPath=%2F{}".format("%2F".join([basedir, subdir]))
-            conda_install_url = urlBase
-            # N.B., the zip file URL is nearly identical to the URL for the individual member files. It's unclear if there's an API for getting the correct URL to the files themselves
-            #pkgUrl = "%2F".join([urlBase, packageName])
-            #repoUrl = "%2F".join([urlBase, "current_repodata.json"])
-            #resp = await session.get(repoUrl)
-
-            if subdir == "noarch":
-                comment += "noarch |"
-            elif subdir == "linux-64":
-                comment += "linux-64 |"
-            elif subdir == "linux-aarch64":
-                comment += "linux-aarch64 |"
-            else:
-                comment += "osx-64 |"
-            comment += f" {packageName} | [{archdir}]({URL})\n"
-
-        # Conda install examples
-        comment += "***\n\nYou may also use `conda` to install these after downloading and extracting the appropriate zip file. From the LinuxArtifacts or OSXArtifacts directories:\n\n"
-        comment += "```\nconda install -c ./packages <package name>\n```\n"
-
-        # Table of containers
-        imageHeader = "***\n\nDocker image(s) built (images for Azure are in the LinuxArtifacts zip file above):\n\n"
-        imageHeader += "Package | Tag | Install with `docker`\n"
-        imageHeader += "--------|-----|----------------------\n"
-
+    for [ci_platform, artifacts] in artifactDict.items():
         for URL, artifact in artifacts:
             if artifact.endswith(".tar.gz"):
                 image_name = artifact.split("/").pop()[: -len(".tar.gz")]
                 if ':' in image_name:
                     package_name, tag = image_name.split(':', 1)
-                    #image_url = URL[:-3]  # trim off zip from format=
-                    #image_url += "file&subPath=%2F{}.tar.gz".format("%2F".join(["images", '%3A'.join([package_name, tag])]))
                     comment += imageHeader
                     imageHeader = "" # only add the header for the first image
-                    comment += f"{package_name} | {tag} | "
-                    comment += f'<details><summary>show</summary>`gzip -dc LinuxArtifacts/images/{image_name}.tar.gz \\| docker load`\n'
-        comment += "\n\n"
-    else:
-        comment += (
-            "No artifacts found on the most recent Azure build. "
-            "Either the build failed, the artifacts have been removed due to age, or the recipe was blacklisted/skipped."
-        )
+                    if ci_platform == "azure":
+                        comment += f"{package_name} | {tag} | Azure | "
+                        comment += "<details><summary>show</summary>Images for Azure are in the LinuxArtifacts zip file above."
+                        comment += f"`gzip -dc LinuxArtifacts/images/{image_name}.tar.gz \\| docker load`</details>\n"
+                    elif ci_platform == "circleci":
+                        comment += f"[{package_name}]({URL}) | {tag} | CircleCI | "
+                        comment += f'<details><summary>show</summary>`curl -L "{URL}" \\| gzip -dc \\| docker load`</details>\n'
+    comment += "\n\n"
+    
+    await send_comment(session, pr, comment)
+
+def compose_azure_comment(artifacts: List[Tuple[str, str]]) -> str:
+    nPackages = len(artifacts)
+
+    if nPackages < 1:
+        return ""
+    
+    comment = ""
+    # Table of packages and zips
+    for URL, artifact in artifacts:
+        if not (package_match := re.match(r"^((.+)\/(.+)\/(.+)\/(.+\.conda|.+\.tar\.bz2))$", artifact)):
+            continue
+        url, archdir, basedir, subdir, packageName = package_match.groups()
+
+        comment += f"{subdir} | {packageName} | [{archdir}.zip]({URL}) | Azure | "
+        comment += f'<details><summary>show</summary>'
+        # Conda install examples
+        comment += f"You may also use `conda` to install after downloading and extracting the zip file. From the {archdir} directory: "
+        comment += "`conda install -c ./packages <package name>`"
+        comment +='</details>\n'
+
     return comment
 
 def compose_circlci_comment(artifacts: List[Tuple[str, str]]) -> str:
@@ -97,11 +90,8 @@ def compose_circlci_comment(artifacts: List[Tuple[str, str]]) -> str:
 
     if nPackages < 1:
         return ""
-    
-    comment = "## CircleCI\n\n"
-    comment += "Package(s) built on CircleCI are ready for inspection:\n\n"
-    comment += "Arch | Package | Repodata\n-----|---------|---------\n"
 
+    comment = ""
     # Table of packages and repodata.json
     for URL, artifact in artifacts:
         if not (package_match := re.match(r"^((.+)\/(.+)\/(.+\.conda|.+\.tar\.bz2))$", URL)):
@@ -110,35 +100,34 @@ def compose_circlci_comment(artifacts: List[Tuple[str, str]]) -> str:
         repo_url = "/".join([basedir, subdir, "repodata.json"])
         conda_install_url = basedir
 
-        if subdir == "noarch":
-            comment += "noarch |"
-        elif subdir == "linux-64":
-            comment += "linux-64 |"
-        elif subdir == "linux-aarch64":
-            comment += "linux-aarch64 |"
-        else:
-            comment += "osx-64 |"
-        comment += f" [{packageName}]({URL}) | [repodata.json]({repo_url})\n"
+        comment += f"{subdir} | [{packageName}]({URL}) | [repodata.json]({repo_url}) | CircleCI | "
+        comment += f'<details><summary>show</summary>'
+        # Conda install examples
+        comment += "You may also use `conda` to install:"
+        comment += f"`conda install -c {conda_install_url} <package name>`"
+        comment +='</details>\n'
 
-    # Conda install examples
-    comment += "***\n\nYou may also use `conda` to install these:\n\n"
-    comment += f"```\nconda install -c {conda_install_url} <package name>\n```\n"
+    return comment
 
-    # Table of containers
-    imageHeader = "***\n\nDocker image(s) built:\n\n"
-    imageHeader += "Package | Tag | Install with `docker`\n"
-    imageHeader += "--------|-----|----------------------\n"
+def compose_gha_comment(artifacts: List[Tuple[str, str]]) -> str:
+    nPackages = len(artifacts)
 
+    if nPackages < 1:
+        return ""
+    
+    comment = ""
+    # Table of packages and zips
     for URL, artifact in artifacts:
-        if artifact.endswith(".tar.gz"):
-            image_name = artifact.split("/").pop()[: -len(".tar.gz")]
-            if ":" in image_name:
-                package_name, tag = image_name.split(":", 1)
-                comment += imageHeader
-                imageHeader = "" # only add the header for the first image
-                comment += f"[{package_name}]({URL}) | {tag} | "
-                comment += f'<details><summary>show</summary>`curl -L "{URL}" \\| gzip -dc \\| docker load`</details>\n'
-    comment += "</details>\n"
+        if not (package_match := re.match(r"^((.+)\/(.+)\/(.+\.conda|.+\.tar\.bz2))$", artifact)):
+            continue
+        url, basedir, subdir, packageName = package_match.groups()
+        comment += f"{subdir} | {packageName} | [{subdir}.zip]({URL}) | GitHub Actions | "
+        comment += f'<details><summary>show</summary>'
+        # Conda install examples
+        comment += "You may also use `conda` to install after downloading and extracting the zip file. "
+        comment += "`conda install -c ./packages <package name>`"
+        comment +='</details>\n'
+
     return comment
 
 # Post a comment on a given PR with its artifacts

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -26,10 +26,11 @@ log = logger.info
 async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> None:
     artifactDict = await fetch_pr_sha_artifacts(session, pr, sha)
     
-    comment = "Package(s) built are ready for inspection:\n\n"
-    comment += "Arch | Package | Zip File / Repodata | CI | Instructions\n"
-    comment += "-----|---------|---------|-----|---------\n"
+    header = "Package(s) built are ready for inspection:\n\n"
+    header += "Arch | Package | Zip File / Repodata | CI | Instructions\n"
+    header += "-----|---------|---------|-----|---------\n"
 
+    comment = ""
     # Table of packages and zips
     for [ci_platform, artifacts] in artifactDict.items():
         if ci_platform == "azure":
@@ -38,6 +39,11 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
             comment += compose_circlci_comment(artifacts)
         elif ci_platform == "github-actions":
             comment += compose_gha_comment(artifacts)
+    if len(comment) == 0:
+        comment = ( "No artifacts found on the most recent builds. "
+            "Either the builds failed, the artifacts have been removed due to age, or the recipe was blacklisted/skipped.")
+    else:
+        comment = header + comment
 
     # Table of containers
     imageHeader = "***\n\nDocker image(s) built:\n\n"

--- a/images/bot/src/bioconda_bot/common.py
+++ b/images/bot/src/bioconda_bot/common.py
@@ -116,7 +116,7 @@ async def fetch_azure_zip_files(session: ClientSession, buildId: str) -> [(str, 
     log("contacting azure %s", url)
     async with session.get(url) as response:
         # Sometimes we get a 301 error, so there are no longer artifacts available
-        if response.status == 301:
+        if response.status == 301 or response.status == 404:
             return artifacts
         res = await response.text()
 


### PR DESCRIPTION
- Get artifacts from GitHubActions for osx-arm64
- Condense packages into one table. It was getting unwieldy with two CI platform sections, let alone three.


Sample comment for https://github.com/bioconda/bioconda-recipes/pull/46775 below:
***
Package(s) built are ready for inspection:

Arch | Package | Zip File / Repodata | CI | Instructions
-----|---------|---------|-----|---------
linux-64 | bioawk-1.0-he4a0461_11.tar.bz2 | [LinuxArtifacts.zip](https://artprodsu6weu.artifacts.visualstudio.com/A27bcc0f9-b22c-4418-83d8-514809b37fb2/25074ded-3133-43ca-af80-895ab87b53cb/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2Jpb2NvbmRhL3Byb2plY3RJZC8yNTA3NGRlZC0zMTMzLTQzY2EtYWY4MC04OTVhYjg3YjUzY2IvYnVpbGRJZC81NTAyMy9hcnRpZmFjdE5hbWUvTGludXhBcnRpZmFjdHM1/content?format=zip) | Azure | <details><summary>show</summary>You may also use `conda` to install after downloading and extracting the zip file. From the LinuxArtifacts directory: `conda install -c ./packages <package name>`</details>
osx-64 | bioawk-1.0-h45fc8d7_11.tar.bz2 | [OSXArtifacts.zip](https://artprodsu6weu.artifacts.visualstudio.com/A27bcc0f9-b22c-4418-83d8-514809b37fb2/25074ded-3133-43ca-af80-895ab87b53cb/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2Jpb2NvbmRhL3Byb2plY3RJZC8yNTA3NGRlZC0zMTMzLTQzY2EtYWY4MC04OTVhYjg3YjUzY2IvYnVpbGRJZC81NTAyMy9hcnRpZmFjdE5hbWUvT1NYQXJ0aWZhY3Rz0/content?format=zip) | Azure | <details><summary>show</summary>You may also use `conda` to install after downloading and extracting the zip file. From the OSXArtifacts directory: `conda install -c ./packages <package name>`</details>
osx-arm64 | bioawk-1.0-he4a7b4a_11.tar.bz2 | [osx-arm64.zip](https://github.com/bioconda/bioconda-recipes/actions/runs/8486033635/artifacts/1370687921) | GitHub Actions | <details><summary>show</summary>You may also use `conda` to install after downloading and extracting the zip file. `conda install -c ./packages <package name>`</details>
linux-aarch64 | [bioawk-1.0-h73052cd_11.tar.bz2](https://output.circle-artifacts.com/output/job/e21c37b3-e61a-45e6-8f59-273ee4d6c4ee/artifacts/0/tmp/artifacts/packages/linux-aarch64/bioawk-1.0-h73052cd_11.tar.bz2) | [repodata.json](https://output.circle-artifacts.com/output/job/e21c37b3-e61a-45e6-8f59-273ee4d6c4ee/artifacts/0/tmp/artifacts/packages/linux-aarch64/repodata.json) | CircleCI | <details><summary>show</summary>You may also use `conda` to install:`conda install -c https://output.circle-artifacts.com/output/job/e21c37b3-e61a-45e6-8f59-273ee4d6c4ee/artifacts/0/tmp/artifacts/packages <package name>`</details>
***

Docker image(s) built:

Package | Tag | CI | Install with `docker`
---------|---------|-----|---------
bioawk | 1.0--he4a0461_11 | Azure | <details><summary>show</summary>Images for Azure are in the LinuxArtifacts zip file above.`gzip -dc LinuxArtifacts/images/bioawk:1.0--he4a0461_11.tar.gz \| docker load`</details>
