### PR TITLE
fix: Use circleci API v1.1 to avoid login error

### DIFF
--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       IMAGE_NAME: bot
-      IMAGE_VERSION: '1.3.0'
+      IMAGE_VERSION: '1.3.1'
 
     steps:
     - uses: actions/checkout@v2

--- a/images/bot/setup.cfg
+++ b/images/bot/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bioconda-bot
-version = 0.0.4
+version = 0.0.5
 
 [options]
 python_requires = >=3.8

--- a/images/bot/src/bioconda_bot/common.py
+++ b/images/bot/src/bioconda_bot/common.py
@@ -160,13 +160,13 @@ async def fetch_circleci_artifacts(session: ClientSession, workflowId: str) -> [
         for job in res_wf_object["items"]:
             if job["name"].startswith(f"build_and_test-"):
                 circleci_job_num = job["job_number"]
-                url = f"https://circleci.com/api/v2/project/gh/bioconda/bioconda-recipes/{circleci_job_num}/artifacts"
+                url = f"https://circleci.com/api/v1.1/project/gh/bioconda/bioconda-recipes/{circleci_job_num}/artifacts"
 
                 async with session.get(url) as response:
+                    response.raise_for_status()
                     res = await response.text()
-
                 res_object = safe_load(res)
-                for artifact in res_object["items"]:
+                for artifact in res_object:
                     zipUrl = artifact["url"]
                     pkg = artifact["path"]
                     if zipUrl.endswith((".conda", ".tar.bz2")): # (currently excluding container images) or zipUrl.endswith(".tar.gz"):


### PR DESCRIPTION
This is to fix https://github.com/bioconda/bioconda-recipes/issues/47663 for the fetch artifacts comment.

We may want to follow it up with updates to use a token, but I wanted to get it to a working state for right now