### PR TITLE
Base: Update to Debian 12.5 

### DIFF
--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -32,6 +32,12 @@ jobs:
       with:
         platforms: arm64
 
+    - name: Info
+      run: |
+        set -xeu
+        podman --version
+        buildah --version
+
     - name: Build
       id: build
       run: |

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: Build & Push
     runs-on: ubuntu-24.04
+    container:
+      # travier/podman-action contains newer podman/buildah versions.
+      image: quay.io/travier/podman-action
+      options: --privileged
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
@@ -28,15 +32,29 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
-    - name: Info
       run: |
-        set -xeu
-        podman --version
-        buildah --version
+        podman run --rm --privileged \
+          docker.io/tonistiigi/binfmt --install arm64
+
+    - name: Install Tools
+      run: |
+        set -eu
+        # jq is not installed in travier/podman-action
+        dnf install -qy \
+          jq
+        rpm -q \
+          buildah podman \
+          coreutils findutils sed \
+          curl jq \
+          | (
+            while read -r line ; do
+              printf %s\\n "${line}"
+              case "${line}" in (*' not installed'*)
+                err=1 ;;
+              esac
+              done
+              exit "${err-0}"
+          )
 
     - name: Build
       id: build

--- a/.github/workflows/base-glibc-busybox-bash.yaml
+++ b/.github/workflows/base-glibc-busybox-bash.yaml
@@ -19,10 +19,10 @@ jobs:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
       MAJOR_VERSION: 3
-      MINOR_VERSION: 0
+      MINOR_VERSION: 1
       IMAGE_NAME: base-glibc-busybox-bash
       BUSYBOX_VERSION: '1.36.1'
-      DEBIAN_VERSION: '12.2'
+      DEBIAN_VERSION: '12.5'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: Build & Push
     runs-on: ubuntu-24.04
+    container:
+      # travier/podman-action contains newer podman/buildah versions.
+      image: quay.io/travier/podman-action
+      options: --privileged
     env:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
@@ -27,15 +31,29 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
-    - name: Info
       run: |
-        set -xeu
-        podman --version
-        buildah --version
+        podman run --rm --privileged \
+          docker.io/tonistiigi/binfmt --install arm64
+
+    - name: Install Tools
+      run: |
+        set -eu
+        # jq is not installed in travier/podman-action
+        dnf install -qy \
+          jq
+        rpm -q \
+          buildah podman \
+          coreutils findutils sed \
+          curl jq \
+          | (
+            while read -r line ; do
+              printf %s\\n "${line}"
+              case "${line}" in (*' not installed'*)
+                err=1 ;;
+              esac
+              done
+              exit "${err-0}"
+          )
 
     - name: Build
       id: build

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -19,9 +19,9 @@ jobs:
       # The base image is not intended to change often and should be used with
       # version tags or checksum IDs, but not via "latest".
       MAJOR_VERSION: 3
-      MINOR_VERSION: 0
+      MINOR_VERSION: 1
       IMAGE_NAME: base-glibc-debian-bash
-      DEBIAN_VERSION: '12.2'
+      DEBIAN_VERSION: '12.5'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/base-glibc-debian-bash.yaml
+++ b/.github/workflows/base-glibc-debian-bash.yaml
@@ -31,6 +31,12 @@ jobs:
       with:
         platforms: arm64
 
+    - name: Info
+      run: |
+        set -xeu
+        podman --version
+        buildah --version
+
     - name: Build
       id: build
       run: |

--- a/images/base-glibc-busybox-bash/Dockerfile.test
+++ b/images/base-glibc-busybox-bash/Dockerfile.test
@@ -24,4 +24,4 @@ RUN arch=$(uname -m) \
     && \
     sh ./Miniforge3-Linux-${arch}.sh -bp /opt/conda \
     && \
-    /opt/conda/bin/conda info --all
+    /opt/conda/bin/conda info --verbose

--- a/images/base-glibc-debian-bash/Dockerfile.test
+++ b/images/base-glibc-debian-bash/Dockerfile.test
@@ -36,4 +36,4 @@ RUN apt-get update -qq \
     && \
     sh ./Miniforge3-Linux-${arch}.sh -bp /opt/conda \
     && \
-    /opt/conda/bin/conda info --all
+    /opt/conda/bin/conda info --verbose


### PR DESCRIPTION
- Update the base images to Debian 12.5,
- build them with a newer Buildah version (addressing https://github.com/bioconda/bioconda-utils/issues/958 ).