### PR TITLE
create-env: Rebuild with newer Buildah, base, deps and fixes

### DIFF
--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -14,7 +14,11 @@ on:
 jobs:
   build:
     name: Build & Push
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    container:
+      # travier/podman-action contains newer podman/buildah versions.
+      image: quay.io/travier/podman-action
+      options: --privileged
     env:
       MAJOR_VERSION: 3
       MINOR_VERSION: 0
@@ -24,9 +28,29 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
+      run: |
+        podman run --rm --privileged \
+          docker.io/tonistiigi/binfmt --install arm64
+
+    - name: Install Tools
+      run: |
+        set -eu
+        # jq is not installed in travier/podman-action
+        dnf install -qy \
+          jq
+        rpm -q \
+          buildah podman \
+          coreutils findutils sed \
+          curl jq \
+          | (
+            while read -r line ; do
+              printf %s\\n "${line}"
+              case "${line}" in (*' not installed'*)
+                err=1 ;;
+              esac
+              done
+              exit "${err-0}"
+          )
 
     - name: Prepare
       id: prepare

--- a/.github/workflows/create-env.yaml
+++ b/.github/workflows/create-env.yaml
@@ -21,7 +21,7 @@ jobs:
       options: --privileged
     env:
       MAJOR_VERSION: 3
-      MINOR_VERSION: 0
+      MINOR_VERSION: 1
       IMAGE_NAME: create-env
 
     steps:

--- a/images/create-env/CHANGELOG.md
+++ b/images/create-env/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 
+## bioconda/create-env 3.1 (2024-06-02)
+
+### Changed
+
+- Rebuild with newer Buildah, `bioconda/base-glibc-busybox-bash:3.1`, `conda`/`mamba` from `bioconda-utils=3.2.0`.
+
+### Fixed
+
+- Fix permissions for license files.
+
+- Fix argument separator `--` handling.
+
+- Ensure env vars don't set defaults.
+
+### Added
+
+- Allow passing PREFIX via `--prefix=...`.
+
+
 ## bioconda/create-env 3.0 (2023-10-17)
 
 ### Changed

--- a/images/create-env/Dockerfile.test
+++ b/images/create-env/Dockerfile.test
@@ -69,7 +69,7 @@ COPY --from=build_conda /opt/conda /opt/conda
 COPY --from=build_conda /opt/conda/env-activate.sh /usr/local/
 RUN set -x && \
     /usr/local/env-execute \
-      conda info --all \
+      conda info --verbose \
     && \
     { set -x && . /usr/local/env-activate.sh && set +x ; } \
     && \

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -1,5 +1,17 @@
 #! /bin/sh -eu
 
+unset \
+  prefix \
+  conda_impl \
+  create_command \
+  env_activate_args \
+  env_activate_file \
+  env_execute_file \
+  remove_paths_globs \
+  strip_files_globs \
+  licenses_path \
+  ;
+
 for arg do
   case "${arg}" in
     --help )

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -68,9 +68,10 @@ end-of-help
       licenses_path="${arg#--licenses-path=}"
       shift ;;
     -- )
+      shift
       break ;;
     -* )
-      printf 'unknown option: %s\n' "${arg}"
+      printf 'unknown option: %s\n' "${arg}" 1>&2
       exit 1 ;;
     * )
       break

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -235,6 +235,16 @@ if [ -n "${licenses_path}" ] ; then
           printf 'failed to copy licenses for %s\n' "${pkg}" 1>&2
           exit 1
         }
+      # Workaround https://github.com/conda/conda-build/issues/5330 :
+      # As of conda-build<=24.5, "info" files like "info/licenses/*" retain their original
+      # permissions which leads to downstream issues if they are too restrictive.
+      # => Fix permissions like conda_build.post.fix_permissions does for package content files.
+      if [ -d "${abs_licenses_path}/${pkg}" ] ; then
+        find "${abs_licenses_path}/${pkg}" \
+          -exec chmod 'u+rw,g+rw,o+r' {} \; \
+          -perm -u=x \
+          -exec chmod 'g+x,o+x' {} \;
+      fi
     done
   )
 fi

--- a/images/create-env/create-env
+++ b/images/create-env/create-env
@@ -4,7 +4,7 @@ for arg do
   case "${arg}" in
     --help )
       cat <<'end-of-help'
-Usage: create-env [OPTIONS]... [--] PREFIX [CONDA_CREATE_ARGS]...
+Usage: create-env [OPTIONS]... [--] [PREFIX] [CONDA_CREATE_ARGS]...
 Use conda (or mamba via --conda=mamba) to create a Conda environment at PREFIX
 according to specifications given by CONDA_CREATE_ARGS.
 
@@ -19,6 +19,8 @@ according to specifications given by CONDA_CREATE_ARGS.
                               script. (default: PREFIX/env-activate.sh)
   --env-execute-script=FILE   Destination path of environment execution script.
                               (default: PREFIX/env-execute)
+  --prefix=PREFIX             Destination path of environment.
+                              If omitted, first positional argument is PREFIX.
   --remove-paths=GLOB         Glob of paths to remove from PREFIX after its
                               creation. Can be passed on multiple times. Will
                               be passed on to `find -path PREFIX/GLOB`.
@@ -57,6 +59,9 @@ end-of-help
           "${arg#--remove-paths=}"
       )"
       shift ;;
+    --prefix=* )
+      prefix="${arg#--prefix=}"
+      shift ;;
     --strip-files=* )
       strip_files_globs="$(
         printf '%s\n' \
@@ -78,13 +83,15 @@ end-of-help
   esac
 done
 
-if [ $# -eq 0 ] ; then
-  printf 'missing argument: environment path\n'
-  exit 1
+if [ -z "${prefix+x}" ] ; then
+  if [ $# -eq 0 ] ; then
+    printf 'missing argument: environment path\n' 1>&2
+    exit 1
+  fi
+  prefix="${1}"
+  shift
 fi
-
-prefix="${1%%/}"
-shift
+prefix="${prefix%%/}"
 
 conda_impl="${conda_impl:-conda}"
 create_command="${create_command-create}"

--- a/images/create-env/install-conda
+++ b/images/create-env/install-conda
@@ -29,16 +29,16 @@ miniconda_boostrap_prefix="$( pwd )/miniconda"
   # Only need `strip` executable from binutils. Other binaries from the package
   # and especially the "sysroot" dependency is only bloat for this container
   # image. (NOTE: The binary needs libgcc-ng which is explicitly added later.)
-  mamba create --yes \
+  conda create --yes \
     --prefix="${conda_install_prefix}" \
     --channel=conda-forge \
     binutils
   cp -aL "${conda_install_prefix}/bin/strip" ./strip
   conda run --prefix="${conda_install_prefix}" strip -- ./strip
-  mamba remove --yes --all \
+  conda remove --yes --all \
     --prefix="${conda_install_prefix}"
 
-  mamba create --yes \
+  conda create --yes \
     --prefix="${conda_install_prefix}" \
     --channel=conda-forge \
     \
@@ -115,7 +115,8 @@ conda config \
 # NB: Running conda after the .pyc removal will recreate some .pyc files.
 #     This is intentional as it speeds up conda startup time.
 conda list --name=base
-conda info --all
+conda info --verbose
+conda --version
 mamba --version
 # Make sure we have the requested conda, mamba versions installed.
 conda list \


### PR DESCRIPTION
Followup to gh-82 and https://github.com/bioconda/bioconda-common/pull/54 .
Includes a workaround for https://github.com/conda/conda-build/issues/5330 .

> ## bioconda/create-env 3.1 (2024-06-02)
> 
> ### Changed
> 
> - Rebuild with newer Buildah, `bioconda/base-glibc-busybox-bash:3.1`, `conda`/`mamba` from `bioconda-utils=3.2.0`.
> 
> ### Fixed
> 
> - Fix permissions for license files.
> 
> - Fix argument separator `--` handling.
> 
> - Ensure env vars don't set defaults.
> 
> ### Added
> 
> - Allow passing PREFIX via `--prefix=...`.
