### PR TITLE
bot: add CircleCI token to call

### DIFF
--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -30,7 +30,7 @@ jobs:
       options: --privileged
     env:
       IMAGE_NAME: bot
-      IMAGE_VERSION: '1.4.0'
+      IMAGE_VERSION: '1.4.1'
 
     steps:
     - uses: actions/checkout@v4

--- a/images/bot/setup.cfg
+++ b/images/bot/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bioconda-bot
-version = 0.0.5
+version = 0.0.6
 
 [options]
 python_requires = >=3.8

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -36,7 +36,7 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
         if ci_platform == "azure":
             comment += compose_azure_comment(artifacts)
         elif ci_platform == "circleci":
-            comment += compose_circlci_comment(artifacts)
+            comment += compose_circleci_comment(artifacts)
         elif ci_platform == "github-actions":
             comment += compose_gha_comment(artifacts)
     if len(comment) == 0:
@@ -91,7 +91,7 @@ def compose_azure_comment(artifacts: List[Tuple[str, str]]) -> str:
 
     return comment
 
-def compose_circlci_comment(artifacts: List[Tuple[str, str]]) -> str:
+def compose_circleci_comment(artifacts: List[Tuple[str, str]]) -> str:
     nPackages = len(artifacts)
 
     if nPackages < 1:


### PR DESCRIPTION
Similar to https://github.com/bioconda/bioconda-utils/pull/1001 

Although the endpoints to list workflow jobs and artifacts used to be accessible to anyone, now there is a 401 response code.

Previously we worked around this by changing the API version back to v1.1, but now it's happening again for both versions. This apparently happens often. https://discuss.circleci.com/t/api-token-needed-to-fetch-artifacts/50881/3 So, it makes sense to just use a token.

(Also fixed a typo.)