### PR TITLE
fix: bot comment should include images built on github actions

### DIFF
--- a/.github/workflows/bot.yaml
+++ b/.github/workflows/bot.yaml
@@ -30,7 +30,7 @@ jobs:
       options: --privileged
     env:
       IMAGE_NAME: bot
-      IMAGE_VERSION: '1.4.0'
+      IMAGE_VERSION: '1.4.1'
 
     steps:
     - uses: actions/checkout@v4

--- a/images/bot/setup.cfg
+++ b/images/bot/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = bioconda-bot
-version = 0.0.5
+version = 0.0.6
 
 [options]
 python_requires = >=3.8

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -53,14 +53,15 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
         for URL, artifact in artifacts:
             if artifact.endswith(".tar.gz"):
                 image_name = artifact.split("/").pop()[: -len(".tar.gz")]
-                comment += imageHeader
-                imageHeader = "" # only add the header for the first image
                 if ':' in image_name:
                     package_name, tag = image_name.split(':', 1)
                 elif '---' in image_name:
                     package_name, tag = image_name.split('---', 1)
                 else:
+                    log(f"Skipping image {image_name}: missing separator")
                     continue
+                comment += imageHeader
+                imageHeader = "" # only add the header for the first image
                 if ci_platform == "azure":
                     comment += f"{package_name} | {tag} | Azure | "
                     comment += "<details><summary>show</summary>Images for Azure are in the LinuxArtifacts zip file above."

--- a/images/bot/src/bioconda_bot/comment.py
+++ b/images/bot/src/bioconda_bot/comment.py
@@ -49,22 +49,29 @@ async def make_artifact_comment(session: ClientSession, pr: int, sha: str) -> No
     imageHeader = "***\n\nDocker image(s) built:\n\n"
     imageHeader += "Package | Tag | CI | Install with `docker`\n"
     imageHeader += "---------|---------|-----|---------\n"
-
     for [ci_platform, artifacts] in artifactDict.items():
         for URL, artifact in artifacts:
             if artifact.endswith(".tar.gz"):
                 image_name = artifact.split("/").pop()[: -len(".tar.gz")]
+                comment += imageHeader
+                imageHeader = "" # only add the header for the first image
                 if ':' in image_name:
                     package_name, tag = image_name.split(':', 1)
-                    comment += imageHeader
-                    imageHeader = "" # only add the header for the first image
-                    if ci_platform == "azure":
-                        comment += f"{package_name} | {tag} | Azure | "
-                        comment += "<details><summary>show</summary>Images for Azure are in the LinuxArtifacts zip file above."
-                        comment += f"`gzip -dc LinuxArtifacts/images/{image_name}.tar.gz \\| docker load`</details>\n"
-                    elif ci_platform == "circleci":
-                        comment += f"[{package_name}]({URL}) | {tag} | CircleCI | "
-                        comment += f'<details><summary>show</summary>`curl -L "{URL}" \\| gzip -dc \\| docker load`</details>\n'
+                elif '---' in image_name:
+                    package_name, tag = image_name.split('---', 1)
+                else:
+                    continue
+                if ci_platform == "azure":
+                    comment += f"{package_name} | {tag} | Azure | "
+                    comment += "<details><summary>show</summary>Images for Azure are in the LinuxArtifacts zip file above."
+                    comment += f"`gzip -dc LinuxArtifacts/images/{image_name}.tar.gz \\| docker load`</details>\n"
+                elif ci_platform == "circleci":
+                    comment += f"[{package_name}]({URL}) | {tag} | CircleCI | "
+                    comment += f'<details><summary>show</summary>`curl -L "{URL}" \\| gzip -dc \\| docker load`</details>\n'
+                elif ci_platform == "github-actions":
+                    comment += f"{package_name} | {tag} | GitHub Actions | "
+                    comment += "<details><summary>show</summary>Images are in the linux-64 zip file above."
+                    comment += f"`gzip -dc images/{image_name}.tar.gz \\| docker load`</details>\n"
     comment += "\n\n"
     
     await send_comment(session, pr, comment)


### PR DESCRIPTION
The "please fetch artifacts" comment command stopped including images when we switched linux-64 builds to GitHub Actions. This includes those in the comment and handles the `---` workaround used because GHA artifacts can't have `:` in the file name.